### PR TITLE
fix(hermes): clear DANGEROUS scan verdict blocking skill installs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/tmchow/illo-skill.git"
       },
       "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters, palettes from your own site's colors.",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "strict": true
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "illo",
   "displayName": "Illo",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters via a built-in character builder, palettes derived from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "author": {
     "name": "Trevin Chow",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "illo",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters, palettes from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "skills": "./skills"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "illo",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters via a built-in character builder, palettes derived from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "author": {
     "name": "Trevin Chow"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "illo",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters, palettes from your own site's colors. Ships the illo Agent Skill; docs at https://illo-skill.com."
 }

--- a/skills/illo/README.md
+++ b/skills/illo/README.md
@@ -38,13 +38,13 @@ named preset, or hand it one brand color and let it derive the rest.
 Same character, different voice — the bundled woodcut style telling a
 three-panel story:
 
-![Woodcut mini-comic example](../../_assets/illo/styles/woodcut-minicomic.png)
+![Woodcut mini-comic example](https://raw.githubusercontent.com/tmchow/illo-skill/main/_assets/illo/styles/woodcut-minicomic.png)
 
 And the day job — compressing an abstract concept into one scene that lands
 in about a second. Hand it *"we replatform with zero downtime"* and you get
 the bridge being rebuilt under live traffic:
 
-![Zero downtime — rebuilding the bridge under live traffic](../../_assets/illo/05-bridgeswap-ink-punch.png)
+![Zero downtime — rebuilding the bridge under live traffic](https://raw.githubusercontent.com/tmchow/illo-skill/main/_assets/illo/05-bridgeswap-ink-punch.png)
 
 One idea per image, the mascot *performing* the move rather than decorating
 it, a few short hand-lettered labels — every render is held to that

--- a/skills/illo/SKILL.md
+++ b/skills/illo/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   when the structure itself is the point — in one of ten bundled print
   looks. Triggers only when the skill is directly invoked or "illo" is
   requested; never on generic illustrate / draw / make-an-image requests.
-version: 0.22.0
+version: 0.22.1
 argument-hint: "[idea or article URL] | build a character | install <character>"
 author: Trevin Chow
 license: MIT

--- a/skills/illo/references/backends.md
+++ b/skills/illo/references/backends.md
@@ -104,8 +104,9 @@ character's reference sheet (`-i <sheet>`) so the mascot stays on-model, and
 asks the agent to save the result to the run-dir path. illo handles **no
 token**: it runs no OAuth, reads no `~/.codex/auth.json`, hits no endpoint —
 the only privileged action is the subprocess call to the user's own CLI
-(the one sanctioned exception to the stdlib-over-subprocess rule; see
-`AGENTS.md`). The adapter verifies the file landed, otherwise fetches the
+(the one sanctioned exception to the stdlib-over-subprocess rule — a benign
+call to a known CLI, not a credential read). The adapter verifies the file
+landed, otherwise fetches the
 freshest image the tool dropped under `$CODEX_HOME/generated_images/`
 (`$CODEX_HOME` resolved at run time — relocatable, never hardcoded).
 

--- a/skills/illo/scripts/illo.py
+++ b/skills/illo/scripts/illo.py
@@ -42,7 +42,7 @@ SKILL_DIR = pathlib.Path(__file__).resolve().parent.parent
 # no API key). illo handles NO token: it runs no OAuth, reads no ~/.codex/auth.json,
 # and hits no endpoint — the only privileged action is a subprocess call to the
 # user's own CLI. Subprocess to `codex` is the ONE sanctioned exception to the
-# stdlib-over-subprocess rule (a benign CLI call, not a credential read); see AGENTS.md.
+# stdlib-over-subprocess rule — a benign call to a known CLI, not a credential read.
 BACKENDS = ("codex", "openrouter")
 # Config schema version. 2 is the first version that has the Codex/OpenRouter
 # backend choice. A config without this key (or below) predates the choice, so


### PR DESCRIPTION
## Problem

A user reported `hermes skills update` blocking illo with a **DANGEROUS** verdict — and `--force` can't override a community + dangerous verdict. Reported as three "false positives": a `backends.md` mention of `AGENTS.md`, `illo.py` using `subprocess.run`, and README `../../_assets/...` paths.

## Root cause

Ran the real scanner (`tools/skills_guard.py` from the local Hermes install) to get ground truth. The verdict logic: **any `critical` finding → `dangerous`**; `medium` findings don't change the verdict. Of the three reported items, only one is critical:

| Finding | Severity | Blocks? |
|---|---|---|
| `AGENTS.md` literal mention (`backends.md`, `illo.py`) | **critical** (`agent_config_mod`) | ✅ **the actual blocker** |
| `subprocess.run` ×2 | medium | no |
| `../../_assets/` ×2 | medium | no |

`skills_guard` flags *any* literal `AGENTS.md`/`CLAUDE.md` string as critical (it's a persistence/agent-config-modification heuristic, no verb required). The Codex commit added two "see AGENTS.md" prose pointers, and those two strings alone forced the dangerous verdict.

## Fix

Verified before/after with the real scanner: **DANGEROUS → SAFE**, BLOCKED → ALLOWED.

- **Remove both `AGENTS.md` cross-references**; state the subprocess-exception rationale inline. Fix-by-removal per the project's own scanner-safe rule — and these were dangling pointers anyway, since `AGENTS.md` is repo-meta that never ships in the install.
- **README image embeds: `../../_assets/...` → raw.githubusercontent URLs.** Clears the two medium traversal findings *and* fixes a real bug (relative `_assets/` links are dead in installs because `_assets/` never ships); matches the "README embeds linked by raw URL" intent already in AGENTS.md.
- **Leave the two `subprocess.run` findings** — medium/non-blocking, and the sanctioned Codex exception per AGENTS.md.
- **Bump `0.22.0 → 0.22.1`** and sync the 5 plugin manifests (publishing is version-gated).

The remaining scan shows only the two medium `subprocess.run` findings → verdict SAFE.

## Note

Raw image URLs target `.../illo-skill/main/_assets/...` — they resolve once this lands on `main`. Pinned to the `main` branch ref rather than an immutable commit (conventional for README embeds).