### PR TITLE
Improve character reroute legibility gates

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/tmchow/illo-skill.git"
       },
       "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters, palettes from your own site's colors.",
-      "version": "0.23.1",
+      "version": "0.23.2",
       "strict": true
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "illo",
   "displayName": "Illo",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters via a built-in character builder, palettes derived from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "author": {
     "name": "Trevin Chow",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "illo",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters, palettes from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "skills": "./skills"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "illo",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters via a built-in character builder, palettes derived from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "author": {
     "name": "Trevin Chow"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "illo",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters, palettes from your own site's colors. Ships the illo Agent Skill; docs at https://illo-skill.com."
 }

--- a/skills/illo/SKILL.md
+++ b/skills/illo/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   when the structure itself is the point — in one of ten bundled print
   looks. Triggers only when the skill is directly invoked or "illo" is
   requested; never on generic illustrate / draw / make-an-image requests.
-version: 0.23.1
+version: 0.23.2
 argument-hint: "[idea or article URL] | build a character | install <character>"
 author: Trevin Chow
 license: MIT
@@ -274,6 +274,11 @@ wins:
 Once resolved, read the pack's `character.md` and use its prompt spec, value
 rules, and `reference.png` everywhere the default's would be used.
 
+When rerouting an article set to a new character — especially after a weak
+attempt, or for a technical/platform essay — read
+`references/article-set-character-reroute.md` in full before planning or
+rendering. Do the legibility preflight there before spending renders.
+
 If the user wants a *new* character, that is the character builder
 (`references/character-builder.md`); if they want someone else's, packs
 install from the community repo (`references/pack-sharing.md`). Either way,
@@ -291,6 +296,11 @@ rule are in `references/composition.md`). When a stretch of the piece advances
 through stages **in one place**, plan a single mini-comic image there instead
 of several — the mini-comic-vs-separate routing is in
 `references/composition.md`.
+
+For article-set character reroutes, add the mandatory preflight fields from
+`references/article-set-character-reroute.md` before any render: section claim,
+visual object/action, and reader mapping. Reject rows that need a private
+metaphor glossary or more than one conceptual substitution.
 
 ### 4. Resolve the palette (the style is the character's)
 
@@ -349,13 +359,15 @@ aspect is 16:9; use `1:1` for social, `9:16`/`4:5` for vertical. Pass `--label`
 for a caption that shows in the gallery.
 
 **Sets read as one artist.** For any multi-image set, the first image that
-**passes the full quality bar** (never an unvetted render — a failed anchor,
-e.g. an off-palette ground, would propagate its failure set-wide) becomes the
-set's **style anchor**: pass it as a second `--ref` after the character sheet
-for every later image in the set and for every re-roll of a set member, so
-line weight, halftone density, and flat-vs-dimensional treatment stay
-consistent throughout. The same trick locks style for a one-off: add any
-finished example as a second `--ref`.
+**passes the full quality bar** (and, for a hero in a rerouted article set,
+passes the thesis-legibility gate in
+`references/article-set-character-reroute.md`; never anchor on an unvetted
+render — a failed anchor, e.g. an off-palette ground or illegible metaphor,
+would propagate its failure set-wide) becomes the set's **style anchor**: pass
+it as a second `--ref` after the character sheet for every later image in the
+set and for every re-roll of a set member, so line weight, halftone density,
+and flat-vs-dimensional treatment stay consistent throughout. The same trick
+locks style for a one-off: add any finished example as a second `--ref`.
 
 **Model choice (OpenRouter backend only).** `--model` and config `model:` are
 an **OpenRouter-only** axis — on the Codex backend the model is automatic

--- a/skills/illo/references/article-set-character-reroute.md
+++ b/skills/illo/references/article-set-character-reroute.md
@@ -1,0 +1,83 @@
+# Article-set character reroute
+
+Use this gate when an article/newsletter set is being rerouted to a different
+character after a weak or failed attempt, or whenever a new mascot/domain world
+is introduced for a technical or platform essay. The expensive failure mode is
+not bad drawing; it is a handsome set whose private metaphor system no longer
+maps to the article.
+
+## Mandatory legibility preflight
+
+Before spending any renders, write a preflight row for every proposed shot:
+
+- **Section claim** — the section-level thesis this image must land, in plain
+  article language.
+- **Visual object/action** — the one object and mascot action that will be
+  visible in the frame.
+- **Reader mapping** — how a reader gets from that object/action back to the
+  section claim without seeing your notes.
+
+Reject or rewrite the shot if the mapping needs either of these:
+
+- a private metaphor glossary ("in this world, the cactus means infra debt");
+- more than one conceptual substitution before the claim becomes clear.
+
+One clean metaphor is allowed and often good. The test is whether the reader can
+name it from the scene, not whether it is literal.
+
+## Technical / platform essays
+
+For technical, infrastructure, SaaS, protocol, or platform pieces, default the
+core scene to native article primitives the reader already knows: accounts,
+permissions, meters, tokens, gates, ledgers, switches, apps, providers, queues,
+keys, quotas, bills, routes. Let the character pack's domain world supply the
+accent, posture, and action — not the entire conceptual system.
+
+Good reroute shape: the mascot pushes a permission gate, carries a token across
+a provider switch, patches a leaky meter, or reconciles a ledger. Risky reroute
+shape: every concept becomes a character-world object that must be decoded
+before the article's claim can be read.
+
+This is not a license to flatten the work into stock SaaS diagrams. Keep the
+illo house style: one fresh physical move, one invented built object, quiet
+space, and a load-bearing mascot. Avoid generic dashboards, formal charts,
+UI mockups, and literal office art.
+
+## Hero before style anchor
+
+In a hero + set, the rerouted hero may become the style anchor only after it
+passes both gates:
+
+1. **Visual quality** — normal quality bar: on-model mascot, palette, restraint,
+   composition, no artifact/title failures.
+2. **Thesis legibility** — a reader can connect the scene to the piece's central
+   claim without a private glossary or a chain of substitutions.
+
+A visually strong but illegible hero is not a safe second reference; it will
+propagate the wrong metaphor into the whole set.
+
+## Explainer mode and labels
+
+Explainer register is valid for multi-image article sets when a section needs a
+traceable structure. Technical sections often become more legible as a flow,
+fan-out, timeline, loop, stack, or system slice than as a pure editorial scene.
+Keep it hand-built and character-led, not a formal flowchart.
+
+Labels and titles are not forbidden, but image models are unreliable with text.
+For editorial article placement, prefer no baked-in titles; the prose and
+caption can do that work. When an explainer needs labels, keep them short,
+parallel, and placed on bare ground. If the final depends on exact words, prefer
+adding labels deterministically after generation or in post-process instead of
+trusting the image model prompt.
+
+## Do-not-overcorrect checks
+
+Before rendering the revised set, confirm all of these are true:
+
+- The mascot is still load-bearing: remove it and the action/claim collapses.
+- The set has not become a literal stock diagram or corporate infographic.
+- At least one clean metaphor or editorial invention remains where it helps the
+  piece feel memorable.
+- Each shot has only one main substitution between object/action and claim.
+- Labels are few, short, and optional unless the section truly needs traceable
+  structure.


### PR DESCRIPTION
## Summary
- add an article-set character reroute reference with mandatory legibility preflight rows
- gate rerouted heroes on thesis legibility before using them as set style anchors
- bump illo to 0.22.2 and sync plugin manifest versions

## Verification
- ruby -ryaml frontmatter parse/check: OK (name=illo, version=0.22.2, desc_len=412)
- python3 .github/scripts/sync_plugin_versions.py --check
- python3 .github/scripts/skill_frontmatter_version.py skills/illo
- python3 -m py_compile .github/scripts/*.py skills/illo/scripts/illo.py
- git status --short -- skills/illo/assets _assets/illo: no asset changes