### PR TITLE
fix(codex): let Codex-only users bootstrap a new character

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/tmchow/illo-skill.git"
       },
       "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters, palettes from your own site's colors.",
-      "version": "0.22.1",
+      "version": "0.22.2",
       "strict": true
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "illo",
   "displayName": "Illo",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters via a built-in character builder, palettes derived from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "author": {
     "name": "Trevin Chow",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "illo",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters, palettes from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "skills": "./skills"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "illo",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters via a built-in character builder, palettes derived from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "author": {
     "name": "Trevin Chow"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "illo",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters, palettes from your own site's colors. Ships the illo Agent Skill; docs at https://illo-skill.com."
 }

--- a/skills/illo/SKILL.md
+++ b/skills/illo/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   when the structure itself is the point — in one of ten bundled print
   looks. Triggers only when the skill is directly invoked or "illo" is
   requested; never on generic illustrate / draw / make-an-image requests.
-version: 0.22.1
+version: 0.22.2
 argument-hint: "[idea or article URL] | build a character | install <character>"
 author: Trevin Chow
 license: MIT

--- a/skills/illo/references/backends.md
+++ b/skills/illo/references/backends.md
@@ -101,8 +101,12 @@ enabling Codex.
 
 illo invokes `codex exec` against the built-in tool, attaching the active
 character's reference sheet (`-i <sheet>`) so the mascot stays on-model, and
-asks the agent to save the result to the run-dir path. illo handles **no
-token**: it runs no OAuth, reads no `~/.codex/auth.json`, hits no endpoint —
+asks the agent to save the result to the run-dir path. With no `--ref` and no
+default character there is nothing to lock to, so illo renders ref-less (a
+one-line note marks it) — matching OpenRouter, and exactly what bootstrapping a
+brand-new character's first model sheet needs (`references/character-builder.md`
+step 4). illo handles **no token**: it runs no OAuth, reads no
+`~/.codex/auth.json`, hits no endpoint —
 the only privileged action is the subprocess call to the user's own CLI
 (the one sanctioned exception to the stdlib-over-subprocess rule — a benign
 call to a known CLI, not a credential read). The adapter verifies the file

--- a/skills/illo/references/character-builder.md
+++ b/skills/illo/references/character-builder.md
@@ -102,7 +102,9 @@ let the move, not the expression, carry the idea.}
 Render each concept as a clean reference sheet — no scene, no labels. Use the
 prompt template below per concept, `--count 2`, aspect `1:1`, into a fresh
 `newrun` dir; build a `gallery` and let the user pick (or iterate). No `--ref`
-on the first round — there is nothing to lock to yet.
+on the first round — there is nothing to lock to yet (both backends render this
+first sheet ref-less; once it exists, every later scene render passes it as
+`--ref`).
 
 ```text
 A 1:1 square character reference sheet (model sheet) for a recurring

--- a/skills/illo/scripts/illo.py
+++ b/skills/illo/scripts/illo.py
@@ -593,7 +593,15 @@ def _codex_refs(refs, cfg):
     """Reference image(s) to attach with `codex exec -i` for character lock. Passes every --ref the caller gives (the active character sheet, plus
     any finished-look style anchor illo adds for set consistency); else falls
     back to a configured default character's reference.png so the mascot still
-    locks if --ref was omitted."""
+    locks if --ref was omitted.
+
+    With neither a --ref nor a default character there is nothing to lock to —
+    a ref-less render, exactly what bootstrapping a brand-new character's first
+    model sheet needs (character-builder step 4). gpt-image-2 via `codex exec`
+    does text-to-image fine with no -i, and OpenRouter already renders ref-less
+    without complaint, so Codex matches it rather than refusing (which had left
+    Codex-only users unable to create a character). A one-line note marks the
+    lockless render so a genuinely-forgotten --ref on a scene is still visible."""
     if refs:
         return list(refs)
     default_char = cfg.get("defaultCharacter")
@@ -601,8 +609,10 @@ def _codex_refs(refs, cfg):
         ref = config_dir() / "characters" / default_char / "reference.png"
         if ref.is_file():
             return [str(ref)]
-    raise BackendUnavailable("Codex backend needs a character reference image "
-                             "(pass --ref <sheet>) for character lock.")
+    sys.stderr.write("note: rendering with no character reference (no --ref, no "
+                     "default character) — expected when bootstrapping a new "
+                     "character's model sheet.\n")
+    return []
 
 
 def cmd_init(args):


### PR DESCRIPTION
## What

The Codex backend refused any render with **no `--ref` and no default character**, raising `BackendUnavailable`. That guard fired in exactly one situation — bootstrapping a brand-new character's first model sheet, which by design has nothing to lock to yet ([`character-builder.md` step 4](../blob/claude/elastic-sutherland-71bd5e/skills/illo/references/character-builder.md)). The result: a **Codex-only user with no OpenRouter key could not create a character at all** through the documented flow. (With a key, it silently fell back to OpenRouter and billed the user, despite Codex being the "free" backend.)

## Why it was wrong

The ref-less refusal was never a gpt-image-2 constraint — `codex exec` does text-to-image fine with no `-i`, and the OpenRouter path already rendered ref-less without complaint. The two backends simply disagreed about the identical "no ref" case, and the guard only ever blocked the one legitimate ref-less render the skill performs.

## Fix

`_codex_refs` now renders ref-less when there's nothing to lock to (matching OpenRouter) instead of raising, and writes a one-line stderr note so a *genuinely* forgotten `--ref` on a scene render stays visible. No new flag — an earlier draft added a `--no-ref` flag, but it would have been single-use ceremony for the skill's one ref-less render, so it was dropped in favor of harmonizing the backends.

## Reviewer notes

- Behavior change is Codex-only; OpenRouter is untouched.
- `--ref` and the default-character fallback still take precedence exactly as before — only the final "nothing to lock to" branch changed from raise → return `[]` + note.
- Version bumped `0.22.1` → `0.22.2`; the 5 plugin manifests synced via `sync_plugin_versions.py` (publishing is gated on the SKILL.md version).
- Docs updated: `character-builder.md` step 4 and `backends.md` character-lock section now state both backends render the first sheet ref-less.

## Verification

- `python3 illo.py` parses clean.
- `_codex_refs([], {})` → returns `[]` with the stderr breadcrumb (lockless bootstrap).
- `_codex_refs(['a.png'], {})` → `['a.png']` (explicit refs still win).