### PR TITLE
docs: model sheet is the source of truth for character consistency

### DIFF
--- a/skills/illo/references/character-builder.md
+++ b/skills/illo/references/character-builder.md
@@ -167,7 +167,13 @@ python3 "$SKILL_DIR/scripts/illo.py" init --no-key --character <name>
 
 Per-run selection ("use <name>") beats the default — SKILL.md step 2. Offer a
 quick proof render: one simple scene with the new mascot performing a move,
-so the user sees it on-model in action.
+**rendered with the pack's `reference.png` passed as `--ref`**, so the user
+sees it on-model in action. The locked sheet is the **single source of
+truth**: derive the preview — and every later scene — by conditioning on it,
+never from the bare prompt or a sketch/seed alone. A sheet and a scene
+generated independently drift into two *different* characters; only
+`--ref`-ing the sheet keeps them the same mascot (the same rule SKILL.md
+step 5 states for generation — it applies to the very first preview too).
 
 Packs are folders: remove one to retire it, copy it to another machine to
 install the character there. If the user wants to share it with everyone,


### PR DESCRIPTION
## What

Clarifies in `references/character-builder.md` (step 5) that a character's **model sheet (`reference.png`) is the single source of truth**, and the preview — plus every later scene — must be rendered by passing that sheet as the engine's `--ref`.

## Why

While building a new character pack we hit this directly: a model sheet and a scene generated *independently* (both conditioned on a rough seed, not on each other) drifted into two visibly **different** characters — same concept, different rendering. The image model re-interprets the prompt fresh each time; only conditioning the scene on the locked sheet keeps the mascot on-model.

SKILL.md step 5 already states this for generation in general. This PR makes it explicit at the point where the trap is easiest to fall into — the very first proof/preview render right after the sheet is chosen — so pack authors lock the sheet first and derive everything downstream from it.

## Change

One paragraph in the character builder's "Install the pack" step. Docs only; no engine change.