### PR TITLE
feat(illo): resolve characters by approximation (aliases)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/tmchow/illo-skill.git"
       },
       "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters, palettes from your own site's colors.",
-      "version": "0.22.2",
+      "version": "0.23.0",
       "strict": true
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "illo",
   "displayName": "Illo",
-  "version": "0.22.2",
+  "version": "0.23.0",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters via a built-in character builder, palettes derived from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "author": {
     "name": "Trevin Chow",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "illo",
-  "version": "0.22.2",
+  "version": "0.23.0",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters, palettes from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "skills": "./skills"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "illo",
-  "version": "0.22.2",
+  "version": "0.23.0",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters via a built-in character builder, palettes derived from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "author": {
     "name": "Trevin Chow"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "illo",
-  "version": "0.22.2",
+  "version": "0.23.0",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters, palettes from your own site's colors. Ships the illo Agent Skill; docs at https://illo-skill.com."
 }

--- a/skills/illo/SKILL.md
+++ b/skills/illo/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   when the structure itself is the point — in one of ten bundled print
   looks. Triggers only when the skill is directly invoked or "illo" is
   requested; never on generic illustrate / draw / make-an-image requests.
-version: 0.22.2
+version: 0.23.0
 argument-hint: "[idea or article URL] | build a character | install <character>"
 author: Trevin Chow
 license: MIT
@@ -259,7 +259,14 @@ what's installed. A user can keep several and pick per run. First match
 wins:
 
 1. **Explicit request** — "use <pack name>", "as <name>": that pack (or the
-   shipped default when asked for by name, `blot`).
+   shipped default when asked for by name, `blot`). When the word matches no
+   pack name, resolve by **approximation**: match it against each installed
+   pack's `Aliases:` line and subject (the `character.md` opening line and
+   Locked design **Body**) — `doctor` prints names + aliases, so this needs
+   no file reads in the common case — and against catalog `description`s
+   (`packs list`). So "use ox" finds a pack subtitled an ox (e.g. `yoke`).
+   On one clear match, use it and name it; on several, ask which; on none,
+   say so before falling through.
 2. **Config default** — `defaultCharacter` from the user config, if set.
 3. **Shipped default** — **Blot** (spec in `references/character.md`, model
    sheet `assets/character-reference.webp`).

--- a/skills/illo/references/character-builder.md
+++ b/skills/illo/references/character-builder.md
@@ -20,7 +20,10 @@ Ask only what changes the design:
 - **Where is the accent?** One small part that will carry the palette accent
   in every image (a tip, a fold, a tail, a topknot).
 - **A name?** Optional — the best names read off the design. Offer one if the
-  user doesn't have one.
+  user doesn't have one. If the chosen name *doesn't* read off the subject
+  (an ox named `yoke`), ask for **aliases** — the words people would summon
+  it by ("ox", "zebu") — and record them in the spec's `Aliases:` line so
+  "use ox" resolves to the pack.
 - **Any must/never elements?** (e.g. "no corporate logo shapes").
 
 Skip questions already answered by context. If the user **already has art** —
@@ -68,6 +71,7 @@ Fill this template (it becomes `character.md` in the pack):
 {One sentence: what it is, and why the name reads off the design.}
 
 Style: **{look name — riso if unset}**
+Aliases: {subject + synonyms, comma-separated — omit this line if the name already reads off the subject}
 
 ## Locked design
 

--- a/skills/illo/references/character.md
+++ b/skills/illo/references/character.md
@@ -82,6 +82,20 @@ image models render the description, not the proper noun. Use the name in
 human-facing copy, captions, and shot lists. A good name reads off the design
 (an ink drop is a *blot*).
 
+When a name *doesn't* read literally off the subject (an ox named `yoke`, a
+mole named `mole` is fine but a robot named `blip` is not), give the pack an
+optional **`Aliases:` line** so users can summon it by what it is — "use ox"
+→ `yoke`. List the subject and common synonyms, comma-separated:
+
+```markdown
+Aliases: ox, zebu, oxen
+```
+
+Aliases are selection keys like the name, so the same global-uniqueness rule
+applies: an alias must not collide with another pack's name or alias, the
+shipped `blot`, or any look name. Absent line = name-only selection (the
+agent can still match on the subject prose, just less reliably).
+
 ## Blot — the shipped default
 
 **Blot** is the default mascot: a small ink drop. Style: riso. The model
@@ -124,9 +138,10 @@ the pack name, and the `doctor` subcommand lists what's installed:
 
 - `character.md` — the written spec: name, locked design, a **prompt spec**
   paragraph for the CHARACTER slot, value rules, a `Style: <name>` line (the
-  pack's one look — a bundled or custom style; absent = riso), and
-  (optionally) personality notes. Everything in "Rules for any character"
-  above still applies.
+  pack's one look — a bundled or custom style; absent = riso), an optional
+  `Aliases:` line (subject synonyms for "use ox"-style selection; see
+  Naming above), and (optionally) personality notes. Everything in "Rules
+  for any character" above still applies.
 - `reference.png` — the character's model sheet, passed as `--ref` in place
   of the default's. It is rendered **in the pack's style**, so sheet and
   scenes always match.

--- a/skills/illo/references/pack-sharing.md
+++ b/skills/illo/references/pack-sharing.md
@@ -74,7 +74,9 @@ SKILL.md step 5); convert before publishing (`sips -s format png in.jpg
    `character.md` if missing. Append an entry to `index.json` (`name`,
    `author`, `version`, `description`, `style` — the pack's look, matching
    its `Style:` line; catalog packs must use a **bundled** look, a custom
-   style can't ship in a pack) and a row to the README catalog table
+   style can't ship in a pack — plus an optional `aliases` array mirroring
+   the spec's `Aliases:` line, so `packs list` matches "use ox" to the pack)
+   and a row to the README catalog table
    (copy an existing row's format). If the character-pack repository includes
    contributor instructions, follow those for the current catalog layout.
 4. **Validate:** `python3 .github/validate.py` from the repo root — fix

--- a/skills/illo/scripts/illo.py
+++ b/skills/illo/scripts/illo.py
@@ -28,6 +28,7 @@ import urllib.error, urllib.request
 ENDPOINT = "https://openrouter.ai/api/v1/chat/completions"
 DEFAULT_PACKS_REPO = "https://raw.githubusercontent.com/tmchow/illo-characters/main"
 PACK_NAME_RE = re.compile(r"[a-z0-9]+(-[a-z0-9]+)*")
+ALIASES_RE = re.compile(r"^Aliases:\s*(.+)$", re.M)
 PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
 # Grok Imagine: best riso quality + cheapest in testing. Note: it is reachable via
 # the API but not in OpenRouter's public /models list, so an account without access
@@ -692,6 +693,22 @@ def character_packs(cdir):
             if (d / "character.md").is_file()}
 
 
+def pack_aliases(pack_dir):
+    """The pack's Aliases: line as a list (subject synonyms for "use ox"-style
+    selection), or [] when absent — lets the agent resolve a character by what
+    it is, not just its pack name."""
+    spec = pack_dir / "character.md"
+    if not spec.is_file():
+        return []
+    m = ALIASES_RE.search(spec.read_text(encoding="utf-8", errors="replace"))
+    return [a.strip() for a in m.group(1).split(",") if a.strip()] if m else []
+
+
+def aka_suffix(aliases):
+    """Display suffix ' (aka a, b)' for an alias list, '' when empty."""
+    return f" (aka {', '.join(aliases)})" if aliases else ""
+
+
 def corrupted_assets():
     """Bundled binary assets that no longer match the known-good hashes in
     assets/checksums.txt — the signature of an installer that decoded
@@ -733,8 +750,10 @@ def cmd_doctor(args):
         lines.append(f"watermark: {', '.join(sorted(cfg['watermark']))} (configured)")
     packs = character_packs(cdir)
     if packs:
-        notes = [n + ("" if (d / "reference.png").is_file() else " (reference.png MISSING)")
-                 for n, d in packs.items()]
+        notes = []
+        for n, d in packs.items():
+            note = n + aka_suffix(pack_aliases(d))
+            notes.append(note + ("" if (d / "reference.png").is_file() else " (reference.png MISSING)"))
         lines.append(f"characters: {', '.join(notes)} (packs in {cdir / 'characters'})")
     default_char = cfg.get("defaultCharacter")
     if default_char:
@@ -885,7 +904,7 @@ def cmd_packs_list(args):
             else:
                 mark = "  [installed]"
         print(f"{name} {p.get('version', '')}  {p.get('author', '')} — "
-              f"{p.get('description', '')}{mark}")
+              f"{p.get('description', '')}{aka_suffix(p.get('aliases') or [])}{mark}")
 
 
 def cmd_packs_show(args):


### PR DESCRIPTION
## Resolve characters by approximation (aliases)

Lets users summon a character pack by **what it is**, not just its pack name — `use ox` now resolves to the pack named `yoke`. Many packs have names that don't read off the subject (`bray`=donkey, `berg`=iceberg, `lure`=anglerfish), so name-only selection missed the obvious word.

### Approach (hybrid)
- **Explicit alias field** — an optional `Aliases:` line in `character.md` (and a mirrored `aliases` array in the catalog `index.json`, handled in the companion repo PR).
- **Agent-side fallback** — `SKILL.md` step 2 now matches an unrecognized `use X` against installed packs' `Aliases:` line + subject prose and the catalog `description`s. So old packs without aliases still resolve via their description text.

### Changes
- **`SKILL.md`** — step 2 approximation fallback; version `0.22.2 → 0.23.0`, synced into all 5 plugin manifests.
- **`references/character.md`** + **`character-builder.md`** — document/collect the optional `Aliases:` line; the builder asks for aliases when the name doesn't read off the subject.
- **`references/pack-sharing.md`** — publish flow notes the optional index `aliases` array.
- **`scripts/illo.py`** — `pack_aliases()` reader + `aka_suffix()` formatter; `doctor` and `packs list` surface `(aka ox, zebu, …)` so resolution needs no file reads in the common case. Engine stays env-free / scanner-safe (no new secret or subprocess paths).

### Backward compatibility
Fully compatible — a missing `Aliases:` line / `aliases` array is a no-op, and the prose fallback covers packs that predate the field. Ships the whole behavior independently of the companion repo.

### Companion PR
The catalog backfill + CI validation live in `tmchow/illo-characters` (separate PR). Merge this one first; neither blocks the other.

### Testing
- `python3 -m py_compile scripts/illo.py` ✅
- `doctor` against an installed `yoke` pack → `characters: yoke (aka ox, zebu, oxen, cattle)` ✅
- `packs list` against a local catalog → `yoke … (aka ox, zebu, oxen, cattle)` ✅
