### PR TITLE
feat: add felt to the bundled look library

### DIFF
--- a/skills/illo/SKILL.md
+++ b/skills/illo/SKILL.md
@@ -42,8 +42,8 @@ This is a configurable house style, not a generic image generator. The
 parameters** — and a character pack carries its **style** with it: one look
 per pack, chosen from the bundled look library (riso — grainy halftone,
 ink-layer offset, paper grain, one bold softly-rounded outline — plus
-blueprint, woodcut, pixel, clay, manila, chalk, phosphor, enamel, and
-gouache) or a custom style file. The default mascot is
+blueprint, woodcut, pixel, clay, manila, chalk, phosphor, enamel,
+gouache, and felt) or a custom style file. The default mascot is
 **Blot**, a deadpan ink-drop in riso. Palettes come
 from presets, the user's own palette file, or one derived color. Whatever the
 parameters, it is intentionally not a photo, not a logo, not a corporate
@@ -129,7 +129,7 @@ checks asset integrity everywhere and will say if repair is ever needed.
 Do not load everything at once. Pull the file that matches the step:
 
 - `references/visual-style.md` — riso, the house default look: the risograph technique, line language, paper/ink, hard do/don'ts.
-- `references/styles/<name>.md` — the rest of the look library (`blueprint`, `woodcut`, `pixel`, `clay`, `manila`, `chalk`, `phosphor`, `enamel`, `gouache`), consumed by character packs. Read the active character's style file in full before generating.
+- `references/styles/<name>.md` — the rest of the look library (`blueprint`, `woodcut`, `pixel`, `clay`, `manila`, `chalk`, `phosphor`, `enamel`, `gouache`, `felt`), consumed by character packs. Read the active character's style file in full before generating.
 - `references/character.md` — the character rules (the load-bearing test, anti-complexity guardrails, value-follows-palette), the default character **Blot**, and the custom-pack format. Read before any character work.
 - `references/character-builder.md` — the guided flow for designing and installing a user's own mascot. Read in full before building or replacing a character.
 - `references/pack-sharing.md` — installing characters from the community repo and publishing a pack via PR. Read before any install/publish request.

--- a/skills/illo/references/character.md
+++ b/skills/illo/references/character.md
@@ -46,6 +46,21 @@ interlocking oversized paperclips"), then judge consistency **in aggregate**
 may shift run to run the way hatching does. Locked parts are checked
 one-by-one; locked treatments are checked as a whole.
 
+### A style may own a richer profile
+
+The guardrails above are the house defaults, tuned for the minimalist bundled
+looks. A **style/look file may deliberately loosen them** for its medium, as
+long as the structural invariants still hold: one readable silhouette, exactly
+ONE focal accent, a load-bearing performance, and an exactly-locked,
+reproducible design. A layered-craft look like `felt`, for example, builds the
+body from many stacked felt pieces in several colors and pins a fuller cute
+face (dot eyes + a small stitched mouth + cheeks) — the richness lives in a
+**locked layer treatment judged in aggregate** plus a **multi-color body with
+one focal accent**, never in loose extra parts. When a pack's `Style:` names
+such a look, that look file's "Character treatment" section governs: read it,
+and judge the pack by the structural invariants plus the look's own QA deltas,
+not by the house minimalism.
+
 ### Value-follows-palette (critical)
 
 The character is built with the same value logic as the rest of the scene, so

--- a/skills/illo/references/styles/felt.md
+++ b/skills/illo/references/styles/felt.md
@@ -1,0 +1,96 @@
+# Felt — style pack
+
+Layered felt-craft: matte wool-felt cutouts stacked in shallow layers on a
+felt ground, soft fuzzy nap on every surface, gentle drop shadows between
+layers. A warm, tactile, characterful look — storybook explainers, food and
+lifestyle, anything cozy and handmade. Unlike the minimalist house looks,
+felt **owns a richer character profile** (see "Character treatment"):
+multi-color layered bodies and a fuller locked face are the point, not a
+violation.
+
+## Prompt blocks (replace the template's LINE LANGUAGE and STYLE lines)
+
+```text
+LINE LANGUAGE: build EVERYTHING — mascot, objects, props — from layered hand-cut FELT pieces with soft rounded edges and a visible fuzzy nap; NO drawn outlines — shapes separate by flat felt color, by the soft drop shadow where one felt layer sits on another, and by occasional simple stitch dashes; the mascot's body itself reads as stacked felt layers (rows of feathers, quills, petals, or tufts), built exactly like every other felt piece in the scene.
+
+STYLE: LAYERED FELT-CRAFT diorama — matte wool-felt cutouts stacked in shallow layers on a felt ground, soft fuzzy fiber texture on every surface, gentle soft drop shadows between stacked layers, slightly imperfect hand-cut edges and small handmade misalignment; NOT glossy, NOT a 3D render, no plastic sheen, no photorealistic depth-of-field, no gradients within a piece (one flat felt color per shape).
+```
+
+## Palette mapping
+
+This look is **multi-color by nature** — bodies and scenes are built from a
+small family of felt colors, not a single structure ink:
+
+- **Felt ground** ← the palette paper, a soft felt backdrop and floor.
+- **Craft color set** ← a small family of 4–6 muted felt hues (the palette's
+  secondary colors, or a soft woodland family) — the layers of the character
+  and the scene props are cut from these.
+- **Structure ink** ← the structure-ink hue, used ONLY for the small face
+  details (dot eyes, nose, mouth) and any fine line — never to outline whole
+  shapes.
+- **Accent** ← the palette accent, matte; the **one focal accent part** of the
+  character + at most 1–2 small scene elements.
+
+Classic default (no palette given): felt ground `#e7e2d2`, structure ink
+`#3a352e`, craft set warm-brown `#9a7b5a` / sage `#8fa682` / dusty-blue
+`#8fa6b0` / oat `#c9bfa6` / clay `#c08a6e`, accent vermilion `#d9482e`.
+
+PALETTE line: `a soft felt ground {paper hex} breathing through. Layered felt
+in a small craft color set {list 4–6 craft hexes by role}; structure-ink
+{structure hex} only for the eyes, nose, mouth and fine detail. Accent
+{accent hex} used sparingly — the character's one focal accent part + at most
+1–2 elements. One flat felt color per shape; soft drop shadows only between
+stacked layers.`
+
+## Character treatment (a richer, style-owned profile)
+
+The mascot is built from the same layered wool felt as the rest of the scene
+— **never a flat drawing or sticker placed in.** Append to the CHARACTER
+block: "the mascot is itself built of stacked hand-cut felt layers exactly
+like every other felt piece in the scene." This look deliberately loosens the
+house minimalism (`references/character.md`, "A style may own a richer
+profile"):
+
+- **Body = locked layer build, judged in aggregate.** The pack names the
+  layer logic ("five staggered quill rows", "scalloped feather tiers"); every
+  render must read as that layered build at a glance, but individual cut
+  pieces may vary run to run the way hatching does. Lock the *read*, not each
+  scrap.
+- **Multi-color body, ONE focal accent.** The body may use several flat craft
+  colors (that is the medium). Exactly one small part is the focal accent in
+  the accent hue — name it and force its hue; the accent never spreads across
+  the body.
+- **Locked cute face.** Cute is welcome and must be pinned exactly: round dot
+  eyes, optionally a small flat or stitched mouth and small oval rosy felt
+  cheeks — identical every render ("a small stitched mouth", not "a happy
+  smile").
+- **One clean silhouette.** Richness comes from layers and fuzz, never from
+  loose extra parts; the outline must still read at any size.
+
+Value mapping: the body keeps its muted felt tones; the structure-ink details
+(eyes, mouth, stitching) use the structure ink, never pure black; the focal
+accent stays the accent hue in every palette.
+
+## Labels
+
+≤2 short hand-lettered English capitals in the structure-ink color directly
+on the bare felt ground — slightly irregular, stitched/painted look. Never
+tiny detailed lettering (it mangles), never on a colored fill.
+
+## QA deltas (replace the riso grain checks)
+
+- **The mascot is layered felt.** A flat/drawn mascot on a felt set = re-roll.
+- Fuzzy fiber texture on every surface; soft drop shadows ONLY between stacked
+  layers — no gradients within a piece, no gloss, no 3D-render sheen, no
+  depth-of-field blur.
+- Face matches the locked spec exactly (eyes/nose/mouth/cheeks as written).
+- Multi-color body is fine, but exactly ONE focal accent part carries the
+  accent hue — force the hue in words next to the hex; the accent never
+  spreads across the whole body.
+- Silhouette reads as one clean shape at small size; layer count stays in the
+  locked band (no detail creep into loose parts).
+
+Calibration example: none bundled yet — study the community felt packs in
+[`illo-characters`](https://github.com/tmchow/illo-characters) (`quill`,
+`plume`, `posy`, `pleat`) for line/texture and accent restraint; never copy
+their compositions.


### PR DESCRIPTION
## What

Adds **`felt`** as a bundled look: layered felt-craft — matte wool-felt cutouts stacked in shallow layers, fuzzy fiber nap, soft drop shadows between layers.

- New `skills/illo/references/styles/felt.md` (LINE LANGUAGE + STYLE blocks, palette mapping, character treatment, QA deltas — same shape as the other style files).
- `felt` added to SKILL.md's look-library lists (overview prose + references index).
- New **"A style may own a richer profile"** note in `references/character.md`.

## Why the character.md note

felt is the library's first **layered-craft** look, and the medium rewards richness the minimalist house looks avoid: multi-color bodies built from many stacked felt pieces, and a fuller locked face (dot eyes + stitched mouth + cheeks). The note makes explicit what was already implicit in the 'material treatment judged in aggregate' rule: a look file may loosen the house defaults for its medium **as long as the structural invariants hold** — one readable silhouette, exactly one focal accent, load-bearing performance, and an exactly-locked, reproducible design. A pack's `Style:` look then governs via its own 'Character treatment' section.

## Proven

The four felt packs in [illo-characters](https://github.com/tmchow/illo-characters) — `quill` (hedgehog), `plume` (owl), `posy` (flower-bud), `pleat` (soup dumpling) — were built and rendered against this look. Docs + one new style file only; no engine change.