### PR TITLE
Bake character-first voice into character builder + pack sharing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/tmchow/illo-skill.git"
       },
       "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters, palettes from your own site's colors.",
-      "version": "0.23.2",
+      "version": "0.23.3",
       "strict": true
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "illo",
   "displayName": "Illo",
-  "version": "0.23.2",
+  "version": "0.23.3",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters via a built-in character builder, palettes derived from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "author": {
     "name": "Trevin Chow",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "illo",
-  "version": "0.23.2",
+  "version": "0.23.3",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters, palettes from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "skills": "./skills"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "illo",
-  "version": "0.23.2",
+  "version": "0.23.3",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters via a built-in character builder, palettes derived from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "author": {
     "name": "Trevin Chow"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,13 @@ Required: `name`, `description`, `version`.
   bundled print looks") — bump the number when adding a look, never
   enumerate names there.
 - `version` — semver; bump on meaningful change. **Publishing is gated on
-  this** (see Publishing below).
+  this** (see Publishing below). "Meaningful change" includes **any edit to
+  shipped skill content** — `SKILL.md`, `references/**`, `scripts/**`,
+  `assets/**` — because those install onto the user's machine and change how
+  the skill behaves. Editing a reference doc is *not* a docs-only change: only
+  repo-meta files (`README.md`, `AGENTS.md`, `CONTRIBUTING`, `.github/**`) are
+  docs-only and skip the bump. When in doubt, bump — an unchanged version is
+  skipped silently at publish, so the fix never reaches installed skills.
 
 Per-runtime metadata (`metadata.hermes`, `metadata.openclaw`) is optional
 and additive — unknown fields are ignored by other runtimes. **Verify every

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "illo",
-  "version": "0.23.2",
+  "version": "0.23.3",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters, palettes from your own site's colors. Ships the illo Agent Skill; docs at https://illo-skill.com."
 }

--- a/skills/illo/SKILL.md
+++ b/skills/illo/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   when the structure itself is the point — in one of ten bundled print
   looks. Triggers only when the skill is directly invoked or "illo" is
   requested; never on generic illustrate / draw / make-an-image requests.
-version: 0.23.2
+version: 0.23.3
 argument-hint: "[idea or article URL] | build a character | install <character>"
 author: Trevin Chow
 license: MIT

--- a/skills/illo/references/character-builder.md
+++ b/skills/illo/references/character-builder.md
@@ -98,7 +98,10 @@ Aliases: {subject + synonyms, comma-separated — omit this line if the name alr
 
 {Default: an earnest, low-key operator doing something slightly absurd with a
 straight face. Adjust freely — keep it consistent with the locked face, and
-let the move, not the expression, carry the idea.}
+let the move, not the expression, carry the idea. Lead with what the character
+*is and does*; if you name a use-case, keep any engineering use as one lens at
+the end, never the headline — the catalog is a cast of mascots, not a devops
+icon set.}
 ```
 
 ## 4. Generate model-sheet candidates

--- a/skills/illo/references/pack-sharing.md
+++ b/skills/illo/references/pack-sharing.md
@@ -77,8 +77,11 @@ SKILL.md step 5); convert before publishing (`sips -s format png in.jpg
    style can't ship in a pack — plus an optional `aliases` array mirroring
    the spec's `Aliases:` line, so `packs list` matches "use ox" to the pack)
    and a row to the README catalog table
-   (copy an existing row's format). If the character-pack repository includes
-   contributor instructions, follow those for the current catalog layout.
+   (copy an existing row's format). Lead the `description` (and the README row)
+   with what the character *is and does*; keep any engineering use as one lens
+   at the end, not the headline — match the catalog's voice, not a devops icon
+   set. If the character-pack repository includes contributor instructions,
+   follow those for the current catalog layout.
 4. **Validate:** `python3 .github/validate.py` from the repo root — fix
    anything it flags (CI runs the same check on the PR).
 5. **Commit, push, open the PR** with both images embedded so review takes


### PR DESCRIPTION
Companion to illo-characters #14/#15. The catalog was reworked so every character leads with what it *is and does* (eng use as one lens at the end), and illo-characters AGENTS.md/CONTRIBUTING now require that voice. This makes the **skill itself** generate copy the same way, so skill-built packs don't reintroduce the eng-jargon framing.

- `references/character-builder.md` — the `## Personality` template now steers toward character-first voice.
- `references/pack-sharing.md` — the `index.json` description + README step says lead with character, keep engineering use as one lens at the end.

Docs only; no behavior/script changes.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/tmchow/illo-skill/pull/9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->