### PR TITLE
Add the diorama look to the bundled library (v0.23.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/tmchow/illo-skill.git"
       },
       "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters, palettes from your own site's colors.",
-      "version": "0.23.3",
+      "version": "0.23.4",
       "strict": true
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "illo",
   "displayName": "Illo",
-  "version": "0.23.3",
+  "version": "0.23.4",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters via a built-in character builder, palettes derived from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "author": {
     "name": "Trevin Chow",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "illo",
-  "version": "0.23.3",
+  "version": "0.23.4",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters, palettes from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "skills": "./skills"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "illo",
-  "version": "0.23.3",
+  "version": "0.23.4",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters via a built-in character builder, palettes derived from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "author": {
     "name": "Trevin Chow"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "illo",
-  "version": "0.23.3",
+  "version": "0.23.4",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters, palettes from your own site's colors. Ships the illo Agent Skill; docs at https://illo-skill.com."
 }

--- a/skills/illo/README.md
+++ b/skills/illo/README.md
@@ -14,7 +14,7 @@ The methodology is the constant; **the character pack and palette are yours
 to set** — and every character pack carries its own print style. Out of the
 box the mascot is **Blot**, a deadpan ink-drop in **risograph**. A built-in
 **character builder** designs your own mascot with you (interview — including
-picking its look from the bundled library of ten ([below](#looks)) — then
+picking its look from the bundled library of twelve ([below](#looks)) — then
 model-sheet candidates → pick → install). Want the same
 character in another look? Build a *style variant pack* (`blot-woodcut`):
 one pack, one look, so a catalog of characters never turns into a grid of
@@ -66,6 +66,8 @@ Every character pack picks exactly one look from the bundled library:
 | **phosphor** | Glowing CRT trace on near-black glass |
 | **enamel** | Hard-enamel pin cells with raised metal lines |
 | **gouache** | Flat matte mid-century poster paint |
+| **felt** | Layered hand-cut wool-felt craft |
+| **diorama** | Watercolor-and-ink storybook tabletop diorama |
 
 Looks are shared infrastructure, deliberately separate from characters: the
 definitions live in this skill (`references/styles/`), and a character pack

--- a/skills/illo/SKILL.md
+++ b/skills/illo/SKILL.md
@@ -4,10 +4,10 @@ description: >-
   Creates original editorial illustrations where a recurring mascot
   character performs the idea — one caught scene by default, or a
   hand-built explainer diagram (a flow, fan-out, timeline, loop, or stack)
-  when the structure itself is the point — in one of ten bundled print
+  when the structure itself is the point — in one of twelve bundled print
   looks. Triggers only when the skill is directly invoked or "illo" is
   requested; never on generic illustrate / draw / make-an-image requests.
-version: 0.23.3
+version: 0.23.4
 argument-hint: "[idea or article URL] | build a character | install <character>"
 author: Trevin Chow
 license: MIT
@@ -43,7 +43,7 @@ parameters** — and a character pack carries its **style** with it: one look
 per pack, chosen from the bundled look library (riso — grainy halftone,
 ink-layer offset, paper grain, one bold softly-rounded outline — plus
 blueprint, woodcut, pixel, clay, manila, chalk, phosphor, enamel,
-gouache, and felt) or a custom style file. The default mascot is
+gouache, felt, and diorama) or a custom style file. The default mascot is
 **Blot**, a deadpan ink-drop in riso. Palettes come
 from presets, the user's own palette file, or one derived color. Whatever the
 parameters, it is intentionally not a photo, not a logo, not a corporate
@@ -129,7 +129,7 @@ checks asset integrity everywhere and will say if repair is ever needed.
 Do not load everything at once. Pull the file that matches the step:
 
 - `references/visual-style.md` — riso, the house default look: the risograph technique, line language, paper/ink, hard do/don'ts.
-- `references/styles/<name>.md` — the rest of the look library (`blueprint`, `woodcut`, `pixel`, `clay`, `manila`, `chalk`, `phosphor`, `enamel`, `gouache`, `felt`), consumed by character packs. Read the active character's style file in full before generating.
+- `references/styles/<name>.md` — the rest of the look library (`blueprint`, `woodcut`, `pixel`, `clay`, `manila`, `chalk`, `phosphor`, `enamel`, `gouache`, `felt`, `diorama`), consumed by character packs. Read the active character's style file in full before generating.
 - `references/character.md` — the character rules (the load-bearing test, anti-complexity guardrails, value-follows-palette), the default character **Blot**, and the custom-pack format. Read before any character work.
 - `references/character-builder.md` — the guided flow for designing and installing a user's own mascot. Read in full before building or replacing a character.
 - `references/pack-sharing.md` — installing characters from the community repo and publishing a pack via PR. Read before any install/publish request.

--- a/skills/illo/references/character-builder.md
+++ b/skills/illo/references/character-builder.md
@@ -15,7 +15,7 @@ Ask only what changes the design:
   simple silhouette.
 - **What look?** The pack's one style: riso (house default) or another from
   the look library — blueprint, woodcut, pixel, clay, manila, chalk,
-  phosphor, enamel, gouache — or a custom style file. The model sheet and
+  phosphor, enamel, gouache, felt, diorama — or a custom style file. The model sheet and
   every scene render in this style.
 - **Where is the accent?** One small part that will carry the palette accent
   in every image (a tip, a fold, a tail, a topknot).
@@ -155,7 +155,7 @@ Pick a pack name — usually the character's name, lowercase kebab-case.
 the community registry with `packs list` before settling, even if the user
 isn't publishing, and avoid the reserved names `blot`, `illo`, and the look
 names (`riso`, `blueprint`, `woodcut`, `pixel`, `clay`, `manila`, `chalk`,
-`phosphor`, `enamel`, `gouache`). With a winner chosen:
+`phosphor`, `enamel`, `gouache`, `felt`, `diorama`). With a winner chosen:
 
 ```bash
 PACK="${XDG_CONFIG_HOME:-$HOME/.config}/illo/characters/<name>"

--- a/skills/illo/references/styles/diorama.md
+++ b/skills/illo/references/styles/diorama.md
@@ -1,0 +1,99 @@
+# Diorama — style pack
+
+Soft hand-drawn children's-book illustration in a slightly elevated isometric
+"tabletop diorama" perspective — peeking down into a tiny self-contained world
+that sits on a surface. Confident dark ink outlines on the main forms, but
+everything filled with loose watercolor-and-gouache washes rather than flat
+color, on heavily textured handmade paper with a warm aged vintage tint. The
+charm is a tension: hard surfaces (rock, paving) render as faceted, low-poly,
+almost crystalline geometric chunks, set against soft organic pillowy foliage.
+A storybook-explainer look — cozy, tactile, miniature-world — that almost
+always reads as a tiny diorama framed by out-of-focus foreground foliage.
+
+## Prompt blocks (replace the template's LINE LANGUAGE and STYLE lines)
+
+```text
+LINE LANGUAGE: confident dark ink outlines on the main forms — the mascot,
+objects and faceted stones — with every shape filled by loose, layered
+watercolor-and-gouache washes rather than flat color (visible brush pooling,
+soft granulation, a little bleed past the line); hard surfaces (rock, paving,
+crystal) drawn as faceted, low-poly, almost crystalline geometric chunks with
+flat planes, while trees, bushes, moss and other foliage stay soft, organic,
+pillowy blobs — the angular-stone-against-soft-foliage tension is the point.
+
+STYLE: soft hand-drawn CHILDREN'S-BOOK TABLETOP DIORAMA — a slightly elevated
+isometric view peeking down into a tiny self-contained world resting on a
+surface, on heavily textured handmade/recycled paper with visible grain and
+fiber and a faint warm aged vintage tint baked into the lighting; out-of-focus
+foliage in the foreground corners vignettes the scene (a gentle tilt-shift
+miniature feel). NOT glossy, NOT a 3D render, no plastic sheen, no photographic
+realism, no neon; washes stay muted and earthy.
+```
+
+## Palette mapping
+
+This look is **multi-color and painterly** — a small muted earthy family of
+washes, not a single structure ink:
+
+- **Paper ground** ← the palette paper: an aged off-white handmade stock, grain
+  and fiber breathing through everywhere.
+- **Wash family** ← a small set of 4–6 muted, slightly desaturated washes (the
+  palette's secondaries, or a soft garden family — sage, olive, warm brown,
+  dusty blue, stone grey) for foliage, stone, water and the mascot's body.
+- **Structure ink** ← the structure-ink hue: a dark warm brown-black for the
+  confident outlines and the small face details (dot eyes) — never pure black.
+- **Accent** ← the palette accent, used sparingly: the character's one focal
+  accent part + at most 1–2 small scene elements.
+
+Classic default (no palette given): paper `#efe7d4`, structure ink `#3a342b`,
+wash family sage `#9caf8f` / olive `#7d8456` / warm-brown `#9a7b57` /
+dusty-blue `#8ba0a8` / stone-grey `#c7c2b6`, accent coral `#e06a3b`.
+
+PALETTE line: `an aged off-white handmade-paper ground {paper hex} with grain
+and fiber throughout. Loose watercolor-and-gouache washes in a small muted
+earthy family {list 4–6 wash hexes by role}; confident structure-ink
+{structure hex} outlines and dot eyes, never pure black. Accent {accent hex}
+used sparingly — the character's one focal accent part + at most 1–2 elements.
+A warm aged vintage tint over the whole frame; faceted stone against soft
+foliage.`
+
+## Character treatment
+
+The mascot is rendered in the **same ink-and-wash technique** as the rest of
+the diorama — confident dark outline, loose washes inside — and may be built
+from the world's own materials (faceted crystalline stone, forged metal and
+glass, paper, moss), never a flat sticker dropped onto a painted scene. It
+still follows the house character rules in `references/character.md`: one clean
+silhouette, a locked, exactly-specified face (house default: two dot eyes,
+blank deadpan, no mouth), and exactly ONE accent-carrying part — the only
+saturated note in an otherwise muted earthy frame.
+
+Value mapping: the body and stone read in muted earthy washes; the structure-
+ink outlines and dot eyes are the deepest value (never pure black); the one
+focal accent stays the accent hue in every palette.
+
+## Labels
+
+≤2 short hand-lettered English capitals in the structure-ink color, painted
+directly on the bare paper ground or a small wooden signpost — slightly
+irregular, storybook hand-painted look. Never tiny detailed lettering (it
+mangles), never on a busy painted fill.
+
+## QA deltas (replace the riso grain checks)
+
+- **It reads as a tiny tabletop diorama.** A flat full-bleed scene with no
+  sense of a small self-contained world on a surface = re-roll.
+- Confident dark ink outlines on the main forms, with loose watercolor/gouache
+  washes inside — NOT flat color, NOT gradients-as-render, no gloss, no 3D
+  sheen, no photographic depth (the only blur is the soft foreground vignette).
+- Hard surfaces are faceted/low-poly crystalline; foliage is soft pillowy
+  blobs — both present, the tension visible.
+- Visible handmade paper grain and a warm aged vintage tint across the frame.
+- The mascot face matches the locked spec exactly; exactly ONE focal accent
+  part carries the accent hue — force the hue next to the hex; it never spreads.
+- One clean silhouette that still reads at small size.
+
+Calibration example: none bundled in-skill — study the community diorama packs
+in [`illo-characters`](https://github.com/tmchow/illo-characters) (`wick`,
+`spritz`, `whorl`) for line/wash/texture and accent restraint; never copy their
+compositions.


### PR DESCRIPTION
Completes the diorama work: the packs (`wick`, `spritz`, `whorl`) shipped in illo-characters, but the skill couldn't render them because `diorama` wasn't a bundled look.

## Adds the look
- **`references/styles/diorama.md`** — the look definition (LINE LANGUAGE / STYLE prompt blocks, palette mapping, character treatment, labels, QA deltas), modeled on `felt.md`. Watercolor-and-ink storybook tabletop diorama: confident dark outlines + loose washes, faceted crystalline stone vs. soft foliage, handmade paper grain, warm vintage tint.
- Registered in **SKILL.md** (look-library list + `references/styles/` list) and **character-builder.md** (look list + reserved-name list).

## Fixes stale counts/lists (felt's addition was incomplete)
- The bundled-look **count** said `ten` in SKILL.md's description and README — stale since `felt` landed. Now **twelve** (riso + 11 style files).
- `felt` was missing from the README looks table and the character-builder lists — added alongside `diorama`.

## Version
`0.23.3 → 0.23.4` (shipped reference content changed), all five plugin manifests synced via `sync_plugin_versions.py`.

After merge + release, the skill can render diorama packs in the new look.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/tmchow/illo-skill/pull/10">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->