### PR TITLE
fix: Codex image artifact generation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/tmchow/illo-skill.git"
       },
       "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters, palettes from your own site's colors.",
-      "version": "0.23.4",
+      "version": "0.23.5",
       "strict": true
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "illo",
   "displayName": "Illo",
-  "version": "0.23.4",
+  "version": "0.23.5",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters via a built-in character builder, palettes derived from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "author": {
     "name": "Trevin Chow",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "illo",
-  "version": "0.23.4",
+  "version": "0.23.5",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters, palettes from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "skills": "./skills"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "illo",
-  "version": "0.23.4",
+  "version": "0.23.5",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters via a built-in character builder, palettes derived from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "author": {
     "name": "Trevin Chow"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "illo",
-  "version": "0.23.4",
-  "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters, palettes from your own site's colors. Ships the illo Agent Skill; docs at https://illo-skill.com."
+  "version": "0.23.5",
+  "description": "Original editorial illustrations where a recurring mascot performs the idea — twelve bundled print looks, custom characters, palettes from your own site's colors. Ships the illo Agent Skill; docs at https://illo-skill.com."
 }

--- a/skills/illo/SKILL.md
+++ b/skills/illo/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   when the structure itself is the point — in one of twelve bundled print
   looks. Triggers only when the skill is directly invoked or "illo" is
   requested; never on generic illustrate / draw / make-an-image requests.
-version: 0.23.4
+version: 0.23.5
 argument-hint: "[idea or article URL] | build a character | install <character>"
 author: Trevin Chow
 license: MIT

--- a/skills/illo/references/backends.md
+++ b/skills/illo/references/backends.md
@@ -67,7 +67,9 @@ does not. The host is "usable Codex" only when **all three** hold:
 
 1. `codex` is on `PATH`;
 2. `codex login status` reports logged in;
-3. `codex features list` reports the `image_generation` feature available.
+3. `codex features list` reports both `image_generation` and `imagegenext`
+   rows are present. `imagegenext` may be default-disabled; illo enables it per
+   render with `--enable imagegenext`, so presence is the capability signal.
 
 Any non-zero exit, timeout, or unparseable output → not usable, and the
 engine soft-falls to OpenRouter. Detection runs once per process and reads
@@ -101,7 +103,19 @@ enabling Codex.
 
 illo invokes `codex exec` against the built-in tool, attaching the active
 character's reference sheet (`-i <sheet>`) so the mascot stays on-model, and
-asks the agent to save the result to the run-dir path. With no `--ref` and no
+asks the agent to save the result to the run-dir path. As of Codex CLI 0.141,
+the stable `image_generation` feature being available is not enough for `exec`
+to expose generated image artifacts reliably; illo also passes
+`--enable imagegenext`. Without that flag the text agent may see the reference
+image and claim it generated an image, while no `$CODEX_HOME/generated_images`
+artifact appears; the agent can then satisfy the requested path with local
+drawing/code, which is not a valid illo render. Keep this flag until Codex
+makes the imagegen extension default or replaces it with a stable equivalent.
+If `imagegenext` hits the known `image_gen` namespace-collision failure
+(openai/codex#28464), illo treats the Codex backend as unavailable and falls
+back to OpenRouter when configured.
+
+With no `--ref` and no
 default character there is nothing to lock to, so illo renders ref-less (a
 one-line note marks it) — matching OpenRouter, and exactly what bootstrapping a
 brand-new character's first model sheet needs (`references/character-builder.md`

--- a/skills/illo/scripts/illo.py
+++ b/skills/illo/scripts/illo.py
@@ -63,6 +63,14 @@ CODEX_EXEC_TIMEOUT = 600
 CODEX_MTIME_SKEW = 2.0
 # `codex features list` row that means the built-in image tool is reachable.
 CODEX_IMAGE_FEATURE = "image_generation"
+# Codex CLI 0.141 exposes generated image artifacts to `codex exec` only when
+# the newer imagegen extension is explicitly enabled. Without this flag, the
+# text agent may see images and even claim it generated one, but no
+# $CODEX_HOME/generated_images/call_*.png artifact appears; the agent may then
+# satisfy the requested output path with local drawing/code, which is not an
+# illo render. Keep this centralized so the flag can be removed when Codex makes
+# the extension default or replaces it with a stable equivalent.
+CODEX_IMAGEGEN_EXT_FEATURE = "imagegenext"
 # Secret-shaped tokens we strip from any captured subprocess output before it
 # could reach a terminal (redact, never print raw stdout/stderr).
 SECRET_RE = re.compile(r"\b(sk-[A-Za-z0-9_-]{8,}|eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_.-]+)")
@@ -103,10 +111,11 @@ _CODEX_AVAILABLE = None  # per-process cache so detection's subprocesses run onc
 
 def codex_available():
     """True iff the host has a USABLE Codex CLI: `codex` on PATH, logged in, and
-    the built-in image_generation feature available. Eligibility is a
-    property of the execution host, detected — never assumed. Soft-fails to False
-    on any non-zero exit, timeout, or unparseable output (→ OpenRouter); reads NO
-    credential file and NO secret-shaped env var. Cached per process."""
+    the built-in image_generation feature plus the imagegenext exec-artifact
+    extension available. Eligibility is a property of the execution host,
+    detected — never assumed. Soft-fails to False on any non-zero exit, timeout,
+    or unparseable output (→ OpenRouter); reads NO credential file and NO
+    secret-shaped env var. Cached per process."""
     global _CODEX_AVAILABLE
     if _CODEX_AVAILABLE is not None:
         return _CODEX_AVAILABLE
@@ -121,9 +130,13 @@ def _detect_codex():
     rc, out = _codex_run(["login", "status"])
     if rc != 0 or "logged in" not in out.lower():
         return False
-    # Built-in image tool reachable? It shows up as a row in `codex features list`.
+    # Built-in image tool reachable, and the exec image-artifact extension
+    # supported? Both show up as rows in `codex features list`.
     rc, out = _codex_run(["features", "list"])
-    if rc != 0 or CODEX_IMAGE_FEATURE not in out.lower():
+    low = out.lower()
+    if (rc != 0
+            or CODEX_IMAGE_FEATURE not in low
+            or CODEX_IMAGEGEN_EXT_FEATURE not in low):
         return False
     return True
 
@@ -442,7 +455,7 @@ def codex_exec_generate(prompt, refs, out_path):
     privileged action is this subprocess to the user's own CLI."""
     if not codex_available():
         raise BackendUnavailable("Codex CLI not usable (not installed, logged out, "
-                                 "or image_generation feature unavailable).")
+                                 "or image_generation/imagegenext unavailable).")
     out = pathlib.Path(out_path).resolve()
     run_dir = out.parent
     run_dir.mkdir(parents=True, exist_ok=True)
@@ -455,7 +468,8 @@ def codex_exec_generate(prompt, refs, out_path):
                     f"then save the resulting image to {out} "
                     f"(overwrite if it exists). Do not ask for confirmation.")
     cmd = ["codex", "exec", "--cd", str(run_dir),
-           "--sandbox", "workspace-write", "--skip-git-repo-check"]
+           "--sandbox", "workspace-write", "--skip-git-repo-check",
+           "--enable", CODEX_IMAGEGEN_EXT_FEATURE]
     # Attach every reference: the active character sheet, plus any finished-look
     # style anchor illo passes for within-set consistency. codex exec -i
     # repeats, so a second --ref is no longer silently dropped.
@@ -483,8 +497,15 @@ def codex_exec_generate(prompt, refs, out_path):
         raise BackendUnavailable(f"codex exec could not run: {e}")
     if proc.returncode != 0:
         # Redact before this string can reach a terminal — never echo raw output.
+        combined = redact((proc.stdout or "") + (proc.stderr or ""))
+        low = combined.lower()
+        if ("tools.namespace" in low and "image_gen" in low and "collid" in low):
+            raise BackendUnavailable(
+                "codex exec imagegenext namespace collision; this Codex CLI build "
+                "cannot use the Codex image backend reliably. Upgrade Codex "
+                "or use the OpenRouter backend.")
         raise BackendUnavailable(
-            f"codex exec exited {proc.returncode}: {redact(proc.stderr)[:300]}")
+            f"codex exec exited {proc.returncode}: {combined[:300]}")
     # Verify-first (the agent's save-to-path works under workspace-write), then
     # fall back to fetching the freshest file the built-in tool dropped under
     # $CODEX_HOME/generated_images/.
@@ -773,14 +794,15 @@ def cmd_doctor(args):
                      f"bash {SKILL_DIR / 'scripts/repair-hermes-assets.sh'}")
     else:
         lines.append("assets: OK")
-    # Codex CLI detection — present / logged-in / image_generation, or why not.
+    # Codex CLI detection — present / logged-in / image_generation + imagegenext,
+    # or why not.
     # codex_available() short-circuits at the first failure, so report by stage.
     # Only fall back to a fresh PATH walk when the cached check already said not-usable.
     if codex_ok:
-        lines.append("codex cli: usable (logged in, image_generation available)")
+        lines.append("codex cli: usable (logged in, image_generation + imagegenext available)")
     elif shutil.which("codex"):
         lines.append("codex cli: present but not usable — run `codex login`, "
-                     "or this host lacks the image_generation feature")
+                     "or this host lacks image_generation/imagegenext support")
     else:
         lines.append("codex cli: not installed (optional — enables free Codex-subscription images)")
     # OpenRouter key (no value ever printed).

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -1,0 +1,148 @@
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any, cast
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "skills" / "illo" / "scripts" / "illo.py"
+
+
+def load_illo_module():
+    spec = importlib.util.spec_from_file_location("illo_script_under_test", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load illo script from {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return cast(Any, module)
+
+
+class FakeCompletedProcess:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class CodexBackendTests(unittest.TestCase):
+    def setUp(self):
+        self.illo = load_illo_module()
+        self.illo.codex_available = lambda: True
+        self.original_run = self.illo.subprocess.run
+
+    def tearDown(self):
+        self.illo.subprocess.run = self.original_run
+
+    def test_codex_exec_enables_imagegenext_and_passes_refs(self):
+        captured = {}
+
+        def fake_run(cmd, input, capture_output, text, timeout):
+            captured["cmd"] = cmd
+            captured["input"] = input
+            captured["capture_output"] = capture_output
+            captured["text"] = text
+            captured["timeout"] = timeout
+            out_path.write_bytes(b"not a real png, just a non-empty artifact")
+            return FakeCompletedProcess(returncode=0)
+
+        with tempfile.TemporaryDirectory() as td:
+            run_dir = Path(td)
+            out_path = run_dir / "render.png"
+            refs = [run_dir / "ref-one.png", run_dir / "ref-two.png"]
+            for ref in refs:
+                ref.write_bytes(b"ref")
+
+            self.illo.subprocess.run = fake_run
+            produced, meta = self.illo.codex_exec_generate(
+                "draw the mascot", [str(r) for r in refs], out_path
+            )
+
+        self.assertEqual(produced, out_path.resolve())
+        self.assertEqual(meta, {"model": None, "id": None})
+        cmd = captured["cmd"]
+        self.assertIn("--enable", cmd)
+        enable_index = cmd.index("--enable")
+        self.assertEqual(cmd[enable_index + 1], self.illo.CODEX_IMAGEGEN_EXT_FEATURE)
+        self.assertEqual(self.illo.CODEX_IMAGEGEN_EXT_FEATURE, "imagegenext")
+        self.assertEqual(cmd.count("-i"), 2)
+        self.assertIn(str(refs[0]), cmd)
+        self.assertIn(str(refs[1]), cmd)
+        self.assertEqual(cmd[-1], "-")
+        self.assertIn("draw the mascot", captured["input"])
+        self.assertIn(str(out_path), captured["input"])
+        self.assertTrue(captured["capture_output"])
+        self.assertTrue(captured["text"])
+        self.assertEqual(captured["timeout"], self.illo.CODEX_EXEC_TIMEOUT)
+
+    def test_detect_codex_requires_imagegenext_row(self):
+        self.illo.shutil.which = lambda name: "/usr/local/bin/codex" if name == "codex" else None
+
+        def fake_codex_run(args):
+            if args == ["login", "status"]:
+                return 0, "Logged in using ChatGPT"
+            if args == ["features", "list"]:
+                return 0, "image_generation stable true\n"
+            raise AssertionError(args)
+
+        self.illo._codex_run = fake_codex_run
+        self.assertFalse(self.illo._detect_codex())
+
+    def test_detect_codex_accepts_imagegenext_even_when_default_disabled(self):
+        self.illo.shutil.which = lambda name: "/usr/local/bin/codex" if name == "codex" else None
+
+        def fake_codex_run(args):
+            if args == ["login", "status"]:
+                return 0, "Logged in using ChatGPT"
+            if args == ["features", "list"]:
+                return 0, (
+                    "image_generation stable true\n"
+                    "imagegenext under development false\n"
+                )
+            raise AssertionError(args)
+
+        self.illo._codex_run = fake_codex_run
+        self.assertTrue(self.illo._detect_codex())
+
+    def test_namespace_collision_is_reported_as_backend_unavailable(self):
+        def fake_run(cmd, input, capture_output, text, timeout):
+            return FakeCompletedProcess(
+                returncode=1,
+                stdout="",
+                stderr=(
+                    "Invalid Value: 'tools.namespace'. User-defined namespace "
+                    "'image_gen' collides with an existing tool namespace."
+                ),
+            )
+
+        with tempfile.TemporaryDirectory() as td:
+            self.illo.subprocess.run = fake_run
+            with self.assertRaises(self.illo.BackendUnavailable) as ctx:
+                self.illo.codex_exec_generate("prompt", [], Path(td) / "out.png")
+
+        self.assertIn("imagegenext namespace collision", str(ctx.exception))
+        self.assertIn("OpenRouter backend", str(ctx.exception))
+
+    def test_generic_codex_error_includes_redacted_combined_output(self):
+        fake_secret = "sk-" + "secretvalue123"
+
+        def fake_run(cmd, input, capture_output, text, timeout):
+            return FakeCompletedProcess(
+                returncode=2,
+                stdout=f"stdout says {fake_secret} should redact",
+                stderr=" stderr details",
+            )
+
+        with tempfile.TemporaryDirectory() as td:
+            self.illo.subprocess.run = fake_run
+            with self.assertRaises(self.illo.BackendUnavailable) as ctx:
+                self.illo.codex_exec_generate("prompt", [], Path(td) / "out.png")
+
+        msg = str(ctx.exception)
+        self.assertIn("codex exec exited 2", msg)
+        self.assertIn("<redacted>", msg)
+        self.assertNotIn(fake_secret, msg)
+        self.assertIn("stderr details", msg)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes the Codex backend invocation so illo's Codex path produces retrievable image-generation artifacts with current Codex CLI behavior.

Current behavior can let `codex exec -i <ref>` expose the reference image to the text agent while failing to expose an actual generated image artifact through the image-generation path. For illo this is severe: the render may appear to succeed while character reference conditioning is effectively broken.

This PR:
- enables Codex's imagegen extension for illo Codex renders
- requires the `imagegenext` capability row during Codex detection
- preserves repeated `-i` reference attachment
- detects the known `imagegenext` / `image_gen` namespace-collision failure from openai/codex#28464 and falls back cleanly
- documents the behavior in backend docs
- adds regression tests for command construction, detection, collision handling, and redaction
- bumps the skill/manifests to `0.23.5`

## Why

illo depends on reference-locked character sheets. If the Codex backend silently runs through the wrong image path, generated mascots can drift completely off-model while still producing files. That makes the backend unsafe for production illustration work.

## Verification

- `python3 .github/scripts/sync_plugin_versions.py --check`
- `python3 -m py_compile skills/illo/scripts/illo.py tests/test_codex_backend.py`
- `python3 -m unittest discover -s tests -v`
- `git diff --cached --check`
- `python3 skills/illo/scripts/illo.py doctor`
- `gh skill publish --dry-run`
- Manual local smoke test on Codex CLI 0.141.0:
  - `codex login status` => logged in using ChatGPT
  - `codex features list` includes `image_generation` and `imagegenext`
  - source-repo `illo.py generate --backend codex ... --ref anvil/reference.png` produced a real PNG artifact

Smoke artifact path from local verification:

```text
/private/tmp/illo-pr-smoke-20260618-174220/pr-smoke.png
PNG image data, 1672 x 941, 8-bit/color RGB, non-interlaced
```

## Related

- openai/codex#28464


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/tmchow/illo-skill/pull/12">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->