### PR TITLE
Add the bricks look to the bundled library (v0.24.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,8 +15,8 @@
         "source": "url",
         "url": "https://github.com/tmchow/illo-skill.git"
       },
-      "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters, palettes from your own site's colors.",
-      "version": "0.24.0",
+      "description": "Original editorial illustrations where a recurring mascot performs the idea — fourteen bundled looks, custom characters, palettes from your own site's colors.",
+      "version": "0.25.0",
       "strict": true
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "illo",
   "displayName": "Illo",
-  "version": "0.24.0",
-  "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters via a built-in character builder, palettes derived from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
+  "version": "0.25.0",
+  "description": "Original editorial illustrations where a recurring mascot performs the idea — fourteen bundled looks, custom characters via a built-in character builder, palettes derived from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "author": {
     "name": "Trevin Chow",
     "url": "https://github.com/tmchow"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "illo",
-  "version": "0.24.0",
-  "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters, palettes from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
+  "version": "0.25.0",
+  "description": "Original editorial illustrations where a recurring mascot performs the idea — fourteen bundled looks, custom characters, palettes from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "skills": "./skills"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "illo",
-  "version": "0.24.0",
-  "description": "Original editorial illustrations where a recurring mascot performs the idea — ten bundled print looks, custom characters via a built-in character builder, palettes derived from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
+  "version": "0.25.0",
+  "description": "Original editorial illustrations where a recurring mascot performs the idea — fourteen bundled looks, custom characters via a built-in character builder, palettes derived from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "author": {
     "name": "Trevin Chow"
   },

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "illo",
-  "version": "0.24.0",
-  "description": "Original editorial illustrations where a recurring mascot performs the idea — twelve bundled print looks, custom characters, palettes from your own site's colors. Ships the illo Agent Skill; docs at https://illo-skill.com."
+  "version": "0.25.0",
+  "description": "Original editorial illustrations where a recurring mascot performs the idea — fourteen bundled looks, custom characters, palettes from your own site's colors. Ships the illo Agent Skill; docs at https://illo-skill.com."
 }

--- a/skills/illo/README.md
+++ b/skills/illo/README.md
@@ -14,7 +14,7 @@ The methodology is the constant; **the character pack and palette are yours
 to set** — and every character pack carries its own print style. Out of the
 box the mascot is **Blot**, a deadpan ink-drop in **risograph**. A built-in
 **character builder** designs your own mascot with you (interview — including
-picking its look from the bundled library of thirteen ([below](#looks)) — then
+picking its look from the bundled library of fourteen ([below](#looks)) — then
 model-sheet candidates → pick → install). Want the same
 character in another look? Build a *style variant pack* (`blot-woodcut`):
 one pack, one look, so a catalog of characters never turns into a grid of
@@ -69,6 +69,7 @@ Every character pack picks exactly one look from the bundled library:
 | **felt** | Layered hand-cut wool-felt craft |
 | **diorama** | Watercolor-and-ink storybook tabletop diorama |
 | **sketchbook** | Vintage sepia pencil-and-ink editorial sketch |
+| **bricks** | Photoreal toy-brick set — the one photographic look |
 
 Looks are shared infrastructure, deliberately separate from characters: the
 definitions live in this skill (`references/styles/`), and a character pack

--- a/skills/illo/SKILL.md
+++ b/skills/illo/SKILL.md
@@ -5,10 +5,10 @@ description: >-
   character performs the idea — one caught scene by default, a hand-built
   explainer diagram (a flow, fan-out, timeline, loop, or stack) when the
   structure itself is the point, or a transparent character cutout
-  (pose-only compositing asset, no scene or text) — in one of thirteen bundled
-  print looks. Triggers only when the skill is directly invoked or "illo" is
+  (pose-only compositing asset, no scene or text) — in one of fourteen bundled
+  looks (thirteen print, plus a photoreal toy-brick set). Triggers only when the skill is directly invoked or "illo" is
   requested; never on generic illustrate / draw / make-an-image requests.
-version: 0.24.0
+version: 0.25.0
 argument-hint: "[idea or article URL] | build a character | install <character>"
 author: Trevin Chow
 license: MIT
@@ -46,10 +46,11 @@ parameters** — and a character pack carries its **style** with it: one look
 per pack, chosen from the bundled look library (riso — grainy halftone,
 ink-layer offset, paper grain, one bold softly-rounded outline — plus
 blueprint, woodcut, pixel, clay, manila, chalk, phosphor, enamel,
-gouache, felt, diorama, and sketchbook) or a custom style file. The default mascot is
+gouache, felt, diorama, sketchbook, and bricks) or a custom style file. The default mascot is
 **Blot**, a deadpan ink-drop in riso. Palettes come
 from presets, the user's own palette file, or one derived color. Whatever the
-parameters, it is intentionally not a photo, not a logo, not a corporate
+parameters, it is intentionally not a photo — with one deliberate exception, the
+`bricks` look, a toy-brick photography style — not a logo, not a corporate
 infographic, not a formal flowchart, not a UI mockup.
 
 ## Use cases — route the request
@@ -133,7 +134,7 @@ checks asset integrity everywhere and will say if repair is ever needed.
 Do not load everything at once. Pull the file that matches the step:
 
 - `references/visual-style.md` — riso, the house default look: the risograph technique, line language, paper/ink, hard do/don'ts.
-- `references/styles/<name>.md` — the rest of the look library (`blueprint`, `woodcut`, `pixel`, `clay`, `manila`, `chalk`, `phosphor`, `enamel`, `gouache`, `felt`, `diorama`, `sketchbook`), consumed by character packs. Read the active character's style file in full before generating.
+- `references/styles/<name>.md` — the rest of the look library (`blueprint`, `woodcut`, `pixel`, `clay`, `manila`, `chalk`, `phosphor`, `enamel`, `gouache`, `felt`, `diorama`, `sketchbook`, `bricks`), consumed by character packs. Read the active character's style file in full before generating.
 - `references/character.md` — the character rules (the load-bearing test, anti-complexity guardrails, value-follows-palette), the default character **Blot**, and the custom-pack format. Read before any character work.
 - `references/character-builder.md` — the guided flow for designing and installing a user's own mascot. Read in full before building or replacing a character.
 - `references/pack-sharing.md` — installing characters from the community repo and publishing a pack via PR. Read before any install/publish request.

--- a/skills/illo/references/character-builder.md
+++ b/skills/illo/references/character-builder.md
@@ -15,7 +15,7 @@ Ask only what changes the design:
   simple silhouette.
 - **What look?** The pack's one style: riso (house default) or another from
   the look library — blueprint, woodcut, pixel, clay, manila, chalk,
-  phosphor, enamel, gouache, felt, diorama, sketchbook — or a custom style file. The model sheet and
+  phosphor, enamel, gouache, felt, diorama, sketchbook, bricks — or a custom style file. The model sheet and
   every scene render in this style.
 - **Where is the accent?** One small part that will carry the palette accent
   in every image (a tip, a fold, a tail, a topknot).
@@ -173,7 +173,7 @@ Pick a pack name — usually the character's name, lowercase kebab-case.
 the community registry with `packs list` before settling, even if the user
 isn't publishing, and avoid the reserved names `blot`, `illo`, and the look
 names (`riso`, `blueprint`, `woodcut`, `pixel`, `clay`, `manila`, `chalk`,
-`phosphor`, `enamel`, `gouache`, `felt`, `diorama`). With a winner chosen:
+`phosphor`, `enamel`, `gouache`, `felt`, `diorama`, `sketchbook`, `bricks`). With a winner chosen:
 
 ```bash
 PACK="${XDG_CONFIG_HOME:-$HOME/.config}/illo/characters/<name>"

--- a/skills/illo/references/styles/bricks.md
+++ b/skills/illo/references/styles/bricks.md
@@ -1,0 +1,109 @@
+# Bricks — style pack
+
+A photograph of a little world built entirely from interlocking toy building
+bricks — the mascot and everything around it assembled from flat, studded
+plastic bricks and shot like a real toy set. This is the skill's **one
+deliberately photographic look** (every other look is illustration/print);
+reach for it when the toy-brick, buildable, "snap it together" voice is the
+point — build sequences, step-by-step explainers, playful product-y scenes,
+launches and missions. A look for **character packs** (the pack's `Style:`
+line).
+
+## Prompt blocks (replace the template's LINE LANGUAGE and STYLE lines)
+
+```text
+LINE LANGUAGE: there are NO drawn outlines — every form is CONSTRUCTED from interlocking toy building-bricks and read by its real molded edges. The ENTIRE scene is brick-built: the ground is a flat STUDDED baseplate, and all terrain, structures, props, even effects (water, smoke, stars) are ASSEMBLED from stacked rectangular bricks, plates and tiles with flat faces, crisp square corners, visible round studs and real seams. Only a few special pieces are smooth and rounded (a molded character head or helmet, a round pearl/dome, a translucent round stud); everything else is blocky.
+
+STYLE: PHOTOREAL TOY-BRICK SET — a real physical brick build PHOTOGRAPHED in studio macro: glossy molded ABS plastic with true reflections, fine surface scuffs and mold seams, realistic soft key light, gentle shadows and a shallow depth of field, on a clean seamless gradient backdrop. It deliberately IS a photograph of a toy. No drawn lines, no flat illustration, no painterly washes, no neon; the brick grid and stud pattern stay legible everywhere.
+```
+
+## Palette mapping
+
+Toy bricks are solid molded colors — the palette maps onto brick colors, not
+inks or washes:
+
+- **Ground** ← a flat studded baseplate in a neutral brick color (the palette
+  paper reinterpreted as plastic: warm sand, stone grey, or deep blue for
+  water).
+- **Body bricks** ← the mascot's bricks follow its value rule using a solid
+  molded color of the structure hue (dark-capable) or a pale plastic
+  (light-bodied).
+- **Structure "ink"** ← the deep recesses, seams and the **printed dot eyes** on
+  the smooth head tile — the darkest value, never pure black.
+- **Accent brick** ← the palette accent as one vivid molded piece: the
+  character's single accent part, plus at most 1–2 small scene bricks.
+- **Translucent pieces** ← trans-clear/trans-blue/trans-amber bricks for water,
+  glass, light and bubbles — the brick way to render an effect.
+
+Classic default (no palette given): sand baseplate `#d8c79a`, body cream
+`#e9e2d0` / navy `#33415c`, structure recess `#2b2b30`, accent warm brass
+`#c89a3c`.
+
+PALETTE line: `the whole build is solid molded plastic bricks on a studded
+{ground hex} baseplate; body bricks {body hexes by role}; deepest seams and
+printed dot eyes {structure hex}, never pure black; exactly one vivid accent
+brick {accent hex} on the character's accent part (+1–2 small bricks at most);
+effects rendered as translucent bricks.`
+
+## Character treatment
+
+The mascot is a small brick minifigure-style toy, **actually built from
+bricks** — stubby brick limbs, simple curved mitten hands, a blocky stud-topped
+torso — never a flat sticker dropped into a photo. It still follows the house
+character rules in `references/character.md`: one clean silhouette, a locked,
+exactly-specified face (house default: two printed dot eyes on a smooth molded
+head, blank deadpan), and exactly ONE accent-carrying part — the single vivid
+brick in an otherwise restrained build. The head or helmet is the main smooth,
+rounded exception to the blocky world.
+
+Value mapping: the body bricks and brick terrain hold their molded values; the
+seam shadows and printed dot eyes are the deepest value (never pure black); the
+one accent brick stays the accent hue in every palette.
+
+> **IP guardrail:** evoke generic toy-brick construction — do not replicate a
+> specific trademarked minifigure's exact proportions or trade dress, and never
+> show real-brand logos on studs. Generic blocky build only.
+
+## Labels
+
+Short capitals printed on small brick **tiles or signs** (a 1x2 printed tile, a
+little brick signpost), ≤2 labels — the toy-set captioning convention. Crisp
+printed lettering reads well here; keep it short and never tiny.
+
+## Staging fit (read before choosing the shot)
+
+Bricks discretize: continuous things become stepped, chunky brick versions of
+themselves (a stream of water becomes an arc of trans-blue studs, smoke becomes
+stacked grey bricks, a curve becomes a staircase of plates). That is the look
+working, not failing — so it shines for **build sequences, step/station
+explainers, before/after, and snap-together stories** (and photo-comic strips,
+since a toy set photographs naturally in panels). Continuous-flow metaphors (a
+single smooth unbroken line, organic blobby growth) fight the medium. Above all
+the WHOLE frame must be brick-built; a brick character standing in a painterly
+or photographic real-world environment is the signature failure.
+
+## QA deltas (replace the riso grain checks)
+
+- **The entire world is brick-built, not just the mascot.** Organic/painterly
+  terrain, real sand, real water, a real chain, a smooth real-world floor =
+  re-roll. Ground must be a studded baseplate; props must be stacked bricks.
+- **It reads as a real photographed toy.** Flat illustration, drawn outlines,
+  painterly washes, or a cartoon render = re-roll (this is the one photographic
+  look — studio macro, true ABS gloss, shallow depth of field).
+- Smooth pieces are limited to molded heads/helmets, round domes/pearls, and
+  translucent studs; everything structural stays flat-faced and studded.
+- The mascot face matches the locked spec exactly — two printed dot eyes on a
+  smooth head; exactly ONE accent brick carries the accent hue (force the hue
+  next to the hex; it never spreads to a second piece).
+- One clean silhouette that still reads at small size.
+- Generic brick construction — no trademarked minifig trade dress, no real-brand
+  logos on the studs.
+
+Calibration example: none bundled in-skill — study the community bricks packs in
+[`illo-characters`](https://github.com/tmchow/illo-characters) (`fathom`,
+`orbit`, `klaxon`) for the brick-built world, accent restraint and toy-photo
+lighting; never copy their compositions.
+
+Variant note: a bricks pack can't reuse a flat illustrated sheet as `--ref` —
+the character must be re-built as a brick minifig and the model sheet shot as a
+studio photo on a plain baseplate; derive every scene from that sheet.


### PR DESCRIPTION
## Summary

Adds **`bricks`** to the bundled look library so the engine can actually render brick-built character packs. Until now `bricks` existed only as packs in illo-characters; the skill had no look definition for it, so those packs couldn't be styled.

`bricks` is the skill's **first deliberately photographic look** — a photoreal toy-brick set where the *whole world* (not just the mascot) is built from flat studded bricks. Every other bundled look is illustration/print.

> [!IMPORTANT]
> Pairs with **tmchow/illo-characters#18** (the `fathom` / `orbit` / `klaxon` packs). Merge **this** first — those packs reference a look the engine can't render until it lands here.

## What's in the look

`references/styles/bricks.md` follows the house style-file format (line language, style, palette mapping, character treatment, labels, staging fit, QA deltas), modeled on the dimensional looks. Its load-bearing rule: the entire frame is brick-built — studded-baseplate floors, brick terrain, effects rendered as translucent bricks — with only molded heads/helmets smooth. Includes an IP guardrail (generic brick build, no trademarked minifig trade dress).

## The "not a photo" exception

The skill's manifesto states output is *"intentionally not a photo."* `bricks` is the one carve-out, now written into that line. This is a deliberate identity decision, not an oversight.

## Bookkeeping

- Registered in all look lists: `SKILL.md` (library + styles), `character-builder.md` (look list + reserved names).
- Look count `twelve` → `thirteen` in `SKILL.md` and `skills/illo/README.md` (+ a looks-table row). Manifest description blurbs normalized (they were stale at `ten`/`twelve`).
- Version `0.24.0` → `0.24.1` across all five manifests.

> **Note:** the root `README.md` marketing copy still says "ten bundled looks" with a "print-style" framing — pre-existing drift (stale since before felt/diorama; the prior look-PR left it too). Updating it now means reframing how the first *photographic* look is presented in headline copy — left as a separate copy decision rather than bundled in here.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/tmchow/illo-skill/pull/14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->