### PR TITLE
Declare skills path in Cursor plugin manifest

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -14,5 +14,6 @@
     "riso",
     "image-generation",
     "mascot"
-  ]
+  ],
+  "skills": "./skills"
 }


### PR DESCRIPTION
## Summary
- Add `"skills": "./skills"` to `.cursor-plugin/plugin.json`, matching the Codex plugin manifest.
- Makes skill discovery explicit for Cursor plugin installs and Marketplace review instead of relying on default folder discovery alone.

## Test plan
- [ ] Confirm `.cursor-plugin/plugin.json` parses as valid JSON
- [ ] Verify `skills/illo/SKILL.md` remains under the declared `./skills` path
- [ ] Optional: symlink repo to `~/.cursor/plugins/local/illo` and reload Cursor to confirm the illo skill appears

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/tmchow/illo-skill/pull/15">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->