### PR TITLE
Add the fizz look to the bundled library (v0.26.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/tmchow/illo-skill.git"
       },
       "description": "Original editorial illustrations where a recurring mascot performs the idea — fourteen bundled looks, custom characters, palettes from your own site's colors.",
-      "version": "0.25.0",
+      "version": "0.26.0",
       "strict": true
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "illo",
   "displayName": "Illo",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — fourteen bundled looks, custom characters via a built-in character builder, palettes derived from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "author": {
     "name": "Trevin Chow",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "illo",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — fourteen bundled looks, custom characters, palettes from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "skills": "./skills"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "illo",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — fourteen bundled looks, custom characters via a built-in character builder, palettes derived from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "author": {
     "name": "Trevin Chow"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "illo",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — fourteen bundled looks, custom characters, palettes from your own site's colors. Ships the illo Agent Skill; docs at https://illo-skill.com."
 }

--- a/skills/illo/README.md
+++ b/skills/illo/README.md
@@ -14,7 +14,7 @@ The methodology is the constant; **the character pack and palette are yours
 to set** — and every character pack carries its own print style. Out of the
 box the mascot is **Blot**, a deadpan ink-drop in **risograph**. A built-in
 **character builder** designs your own mascot with you (interview — including
-picking its look from the bundled library of fourteen ([below](#looks)) — then
+picking its look from the bundled library of fifteen ([below](#looks)) — then
 model-sheet candidates → pick → install). Want the same
 character in another look? Build a *style variant pack* (`blot-woodcut`):
 one pack, one look, so a catalog of characters never turns into a grid of
@@ -70,6 +70,7 @@ Every character pack picks exactly one look from the bundled library:
 | **diorama** | Watercolor-and-ink storybook tabletop diorama |
 | **sketchbook** | Vintage sepia pencil-and-ink editorial sketch |
 | **bricks** | Photoreal toy-brick set — the one photographic look |
+| **fizz** | Psychedelic soda-pop skate-sticker screenprint |
 
 Looks are shared infrastructure, deliberately separate from characters: the
 definitions live in this skill (`references/styles/`), and a character pack

--- a/skills/illo/SKILL.md
+++ b/skills/illo/SKILL.md
@@ -5,10 +5,10 @@ description: >-
   character performs the idea — one caught scene by default, a hand-built
   explainer diagram (a flow, fan-out, timeline, loop, or stack) when the
   structure itself is the point, or a transparent character cutout
-  (pose-only compositing asset, no scene or text) — in one of fourteen bundled
-  looks (thirteen print, plus a photoreal toy-brick set). Triggers only when the skill is directly invoked or "illo" is
+  (pose-only compositing asset, no scene or text) — in one of fifteen bundled
+  looks (fourteen print, plus a photoreal toy-brick set). Triggers only when the skill is directly invoked or "illo" is
   requested; never on generic illustrate / draw / make-an-image requests.
-version: 0.25.0
+version: 0.26.0
 argument-hint: "[idea or article URL] | build a character | install <character>"
 author: Trevin Chow
 license: MIT
@@ -46,7 +46,7 @@ parameters** — and a character pack carries its **style** with it: one look
 per pack, chosen from the bundled look library (riso — grainy halftone,
 ink-layer offset, paper grain, one bold softly-rounded outline — plus
 blueprint, woodcut, pixel, clay, manila, chalk, phosphor, enamel,
-gouache, felt, diorama, sketchbook, and bricks) or a custom style file. The default mascot is
+gouache, felt, diorama, sketchbook, bricks, and fizz) or a custom style file. The default mascot is
 **Blot**, a deadpan ink-drop in riso. Palettes come
 from presets, the user's own palette file, or one derived color. Whatever the
 parameters, it is intentionally not a photo — with one deliberate exception, the
@@ -134,7 +134,7 @@ checks asset integrity everywhere and will say if repair is ever needed.
 Do not load everything at once. Pull the file that matches the step:
 
 - `references/visual-style.md` — riso, the house default look: the risograph technique, line language, paper/ink, hard do/don'ts.
-- `references/styles/<name>.md` — the rest of the look library (`blueprint`, `woodcut`, `pixel`, `clay`, `manila`, `chalk`, `phosphor`, `enamel`, `gouache`, `felt`, `diorama`, `sketchbook`, `bricks`), consumed by character packs. Read the active character's style file in full before generating.
+- `references/styles/<name>.md` — the rest of the look library (`blueprint`, `woodcut`, `pixel`, `clay`, `manila`, `chalk`, `phosphor`, `enamel`, `gouache`, `felt`, `diorama`, `sketchbook`, `bricks`, `fizz`), consumed by character packs. Read the active character's style file in full before generating.
 - `references/character.md` — the character rules (the load-bearing test, anti-complexity guardrails, value-follows-palette), the default character **Blot**, and the custom-pack format. Read before any character work.
 - `references/character-builder.md` — the guided flow for designing and installing a user's own mascot. Read in full before building or replacing a character.
 - `references/pack-sharing.md` — installing characters from the community repo and publishing a pack via PR. Read before any install/publish request.

--- a/skills/illo/references/character-builder.md
+++ b/skills/illo/references/character-builder.md
@@ -15,7 +15,7 @@ Ask only what changes the design:
   simple silhouette.
 - **What look?** The pack's one style: riso (house default) or another from
   the look library — blueprint, woodcut, pixel, clay, manila, chalk,
-  phosphor, enamel, gouache, felt, diorama, sketchbook, bricks — or a custom style file. The model sheet and
+  phosphor, enamel, gouache, felt, diorama, sketchbook, bricks, fizz — or a custom style file. The model sheet and
   every scene render in this style.
 - **Where is the accent?** One small part that will carry the palette accent
   in every image (a tip, a fold, a tail, a topknot).
@@ -173,7 +173,7 @@ Pick a pack name — usually the character's name, lowercase kebab-case.
 the community registry with `packs list` before settling, even if the user
 isn't publishing, and avoid the reserved names `blot`, `illo`, and the look
 names (`riso`, `blueprint`, `woodcut`, `pixel`, `clay`, `manila`, `chalk`,
-`phosphor`, `enamel`, `gouache`, `felt`, `diorama`, `sketchbook`, `bricks`). With a winner chosen:
+`phosphor`, `enamel`, `gouache`, `felt`, `diorama`, `sketchbook`, `bricks`, `fizz`). With a winner chosen:
 
 ```bash
 PACK="${XDG_CONFIG_HOME:-$HOME/.config}/illo/characters/<name>"

--- a/skills/illo/references/styles/fizz.md
+++ b/skills/illo/references/styles/fizz.md
@@ -1,0 +1,94 @@
+# Fizz — style pack
+
+A high-energy psychedelic soda-pop screenprint: 1990s/early-2000s skate
+stickers, underground comics, cereal-box mascots, punk flyers and psychedelic
+beverage packaging. Thick, hand-inked **dark-blue or purple** outlines (never
+black), flat screen-printed fills in loud high-contrast color, and comic energy
+everywhere — bubbles, drips, starbursts, speed lines. Playful, weird, slightly
+chaotic, handmade; the deliberate opposite of clean corporate vector. A look
+for **character packs** (the pack's `Style:` line), suited to launches, hype,
+energy, motion and anything loud and fun.
+
+## Prompt blocks (replace the template's LINE LANGUAGE and STYLE lines)
+
+```text
+LINE LANGUAGE: outline EVERYTHING — mascot, objects, arrows, labels — in THICK, hand-inked DARK BLUE or PURPLE lines, NEVER black. Lines are wobbly and hand-drawn with rounded, imperfect curves and uneven, lively line weight; bold and confident, like a screen-printed skate sticker, not a clean vector.
+
+STYLE: 1990s/early-2000s SKATE-STICKER + UNDERGROUND-COMIC + CEREAL-BOX-MASCOT + PSYCHEDELIC-BEVERAGE screenprint. FLAT fills, minimal-to-no shading, bold high-contrast color blocks. Slight screen-printed/sticker roughness and faint misregistration; exaggerated, expressive, goofy-surreal shapes with oversized features. Pack the energy in: motion splashes, starbursts, bubbles, liquid drips, speed lines, comic impact marks. NOT glossy, NOT 3D, NOT photoreal, NOT minimal SaaS-vector — handmade and a little chaotic.
+```
+
+## Palette mapping
+
+The loud palette maps onto flat screenprint inks, not washes:
+
+- **Paper / ground** ← the palette paper, default warm **cream** (`#f6ecd2`),
+  visible as the breathing background.
+- **Structure ink** ← the outline color, a **deep blue or purple near-black**
+  (default cobalt-purple `#2b2b6b`) — every outline and all the lettering.
+  True black is wrong for this look.
+- **Fills** ← the loud set, one flat tone per shape, 3–5 colors per image:
+  bright orange `#ff7a1a`, lemon yellow `#ffd21e`, cobalt blue `#1f5fff`, neon
+  green `#3fd23f`, hot pink `#ff5fa2`, red `#ef2d2d`, plus cream.
+- **Accent** ← the palette accent, for the character's accent part + 1–2 energy
+  marks.
+
+Classic default (no palette given): cream paper `#f6ecd2`, cobalt-purple ink
+`#2b2b6b`, fills from orange / yellow / cobalt / neon-green, accent neon green
+`#3fd23f`.
+
+PALETTE line: `cream paper {paper hex}, every outline + lettering in deep
+blue-purple ink {structure hex}, never black. Flat blocks of {2-3 loud fill
+hexes}, one flat tone per shape. Accent {accent hex} on the character's accent
+part and 1-2 energy marks. No gradients.`
+
+## Character treatment
+
+The mascot is outlined in the same thick wobbly blue-purple ink as everything
+else and filled with flat blocks of the loud palette. It still follows the
+house character rules in `references/character.md`: one clean silhouette, a
+locked, exactly-specified face, and exactly ONE accent-carrying part. This look
+runs HOT, so the face is usually expressive rather than deadpan — big eyes, a
+grin, motion — but the parts stay locked; emotion comes from their shape. Eyes
+are cream with dark blue-purple pupils. The accent part is one clean
+accent-color shape. Energy marks (bubbles, drips, speed lines) belong to the
+*scene*, not the character — keep any baked into a cutout physically connected
+to the body.
+
+## Labels
+
+Chunky hand-drawn display lettering in the blue-purple ink — optionally filled
+with one loud color and outlined — warped, stretched, slightly irregular, part
+of the illustration, never a clean typeset UI label. ≤2 labels; keep them short
+and bold.
+
+## Staging fit (read before choosing the shot)
+
+Fizz is built for momentum: launches, releases, hype, energy, motion,
+before/after bursts, "ship it" beats and loud announcements. The energy marks
+(splashes, starbursts, speed lines, fizz) are the medium doing its job, so
+action scenes shine. Quiet, sober, minimal or corporate-clean subjects fight
+the look — if a scene wants restraint and white space above all, reach for a
+calmer look instead.
+
+## QA deltas (replace the riso grain checks)
+
+- Every outline is **deep blue or purple, never black** — if lines read black,
+  re-roll.
+- Flat fills, one tone per shape — **no gradients, no soft shading, no gloss,
+  no 3D, no photoreal.**
+- At least a few **comic energy marks** present (bubbles / drips / starbursts /
+  speed lines) — if the image is calm and sterile, it has drifted toward clean
+  vector; re-roll.
+- Lines are **wobbly and hand-drawn**, not crisp geometric vector.
+- The mascot face matches the locked spec exactly; exactly ONE accent part
+  carries the accent hue (force the hue next to the hex; it never spreads).
+- One clean silhouette that still reads at small size.
+
+Calibration example: none bundled in-skill — study the community fizz packs in
+[`illo-characters`](https://github.com/tmchow/illo-characters) (`kick`, `pop`,
+`boom`) for the line weight, flat loud fills and energy-mark restraint; never
+copy their compositions.
+
+Variant note: a flat riso/illustrated sheet can be reused as `--ref` for a fizz
+pack — the style prompt re-renders it in the fizz look. As always, lock the
+model sheet first, then derive every scene from it.


### PR DESCRIPTION
## Add the `fizz` look (v0.26.0)

A new bundled look: **fizz** — a high-energy psychedelic soda-pop screenprint
drawn from 1990s/early-2000s skate stickers, underground comics, cereal-box
mascots, punk flyers and psychedelic beverage packaging.

**Visual signature:** thick, hand-inked **dark-blue/purple** outlines (never
black), wobbly hand-drawn curves, flat loud screen-printed fills on cream, and
comic energy everywhere — bubbles, drips, starbursts, speed lines. The
deliberate opposite of clean corporate vector. Fourteenth print look (fifteenth
overall, alongside the photographic `bricks`).

### What's in the PR
- `references/styles/fizz.md` — the look: `LINE LANGUAGE` + `STYLE` prompt
  blocks, palette mapping, character treatment, labels, staging fit, QA deltas.
- Registered in `SKILL.md` (×2 look lists + count), `references/character-builder.md`
  (×2 lists), and the `README.md` looks table + count (fourteen → fifteen).
- Version bump `0.25.0 → 0.26.0` across the four plugin manifests + `SKILL.md`.

### The look in action
First three fizz packs (in the companion illo-characters PR):

| Kick (sneaker) | Pop (soda can) | Boom (boombox) |
|---|---|---|
| ![kick](https://raw.githubusercontent.com/tmchow/illo-characters/tmchow/fizz-character-packs/packs/kick/preview.png) | ![pop](https://raw.githubusercontent.com/tmchow/illo-characters/tmchow/fizz-character-packs/packs/pop/preview.png) | ![boom](https://raw.githubusercontent.com/tmchow/illo-characters/tmchow/fizz-character-packs/packs/boom/preview.png) |

### Merge order
**Merge this first.** The companion **illo-characters** PR (kick/pop/boom) names
`fizz` as its `Style:`, so those packs only render correctly once this look ships
in the skill.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/tmchow/illo-skill/pull/16">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->