### PR TITLE
Allow floating thesis titles + wire labels to per-look lettering (v0.27.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/tmchow/illo-skill.git"
       },
       "description": "Original editorial illustrations where a recurring mascot performs the idea — fourteen bundled looks, custom characters, palettes from your own site's colors.",
-      "version": "0.26.0",
+      "version": "0.27.0",
       "strict": true
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "illo",
   "displayName": "Illo",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — fourteen bundled looks, custom characters via a built-in character builder, palettes derived from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "author": {
     "name": "Trevin Chow",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "illo",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — fourteen bundled looks, custom characters, palettes from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "skills": "./skills"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "illo",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — fourteen bundled looks, custom characters via a built-in character builder, palettes derived from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "author": {
     "name": "Trevin Chow"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "illo",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — fourteen bundled looks, custom characters, palettes from your own site's colors. Ships the illo Agent Skill; docs at https://illo-skill.com."
 }

--- a/skills/illo/SKILL.md
+++ b/skills/illo/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   (pose-only compositing asset, no scene or text) — in one of fifteen bundled
   looks (fourteen print, plus a photoreal toy-brick set). Triggers only when the skill is directly invoked or "illo" is
   requested; never on generic illustrate / draw / make-an-image requests.
-version: 0.26.0
+version: 0.27.0
 argument-hint: "[idea or article URL] | build a character | install <character>"
 author: Trevin Chow
 license: MIT

--- a/skills/illo/references/composition.md
+++ b/skills/illo/references/composition.md
@@ -344,7 +344,12 @@ at most one short label per panel.
   (Explainer images swap these numbers for that register's budget, above —
   everything else here applies to both registers.)
 - A few accent touches — never a colored-in scene.
-- Don't write the staging's name or any diagram-style title on the image.
+- No boxed title bar or diagram-style header, and don't write the staging's
+  name. A short *floating* thesis title — a few words on bare paper, like a
+  caption that completes the piece — is fine and counts as one of the labels;
+  reach for it when it lands the idea, skip it when the scene already speaks.
+  Honor an explicit request either way: add a title when the user asks for one,
+  omit it when they say no title.
 
 ## Reinvent each time
 

--- a/skills/illo/references/prompt-recipe.md
+++ b/skills/illo/references/prompt-recipe.md
@@ -9,8 +9,11 @@ values from `palettes.md`.
 The template below is written for **riso**. When the active character's pack
 declares a different style (its `Style:` line — SKILL.md step 4), replace the
 LINE LANGUAGE and STYLE lines with the blocks from that style's file, build
-the PALETTE line from its palette mapping, and apply its character treatment
-to the CHARACTER block's value-rule slot.
+the PALETTE line from its palette mapping, refine the LABELS line with the
+style's `## Labels` section so the lettering matches the look (its treatment
+and per-look count — e.g. a blocky pixel font, draftsman capitals, an
+office-stamp impression — override the generic "hand-lettered" default), and
+apply its character treatment to the CHARACTER block's value-rule slot.
 
 ## Generation template
 
@@ -27,7 +30,7 @@ STYLE: risograph print — grainy halftone texture, slight ink-layer offset, fai
 
 PALETTE: paper {paper hex}. Structure ink {structure hex} for all linework, forms, and label text. Accent {accent hex} used sparingly — the character's accent part + 1–2 elements. {optional secondary accent hex for one secondary note}.
 
-LABELS: exactly {1–3} short hand-lettered English labels — {"label one", "label two"} — in the structure-ink color placed directly on the bare paper. Never put label text on a colored fill. No title bar, no type label, no logo.
+LABELS: exactly {1–3} short hand-lettered English labels — {"label one", "label two"} — in the structure-ink color placed directly on the bare paper; one may be a short floating thesis title when it completes the piece. Never put label text on a colored fill. No title bar, no type label, no logo.
 ```
 
 ## Cutout variant


### PR DESCRIPTION
## What & why

The editorial default register carried a **blanket anti-title restraint** (`composition.md`) that suppressed even a short *floating thesis title* — the kind that completes a piece (the "zero downtime" look). It conflated two different things under one prohibition:

- a **boxed title bar** / diagram-style header → correctly banned
- a **floating thesis title** (a few words on bare paper) → useful, but collateral damage

This carves them apart:

- **`references/composition.md`** — a short floating thesis title is now allowed when it lands the idea, skipped when the scene already speaks, and **honored either way when the user explicitly asks for or against one**. Boxed title bars stay banned.
- **`references/prompt-recipe.md`** — the editorial `LABELS:` line now permits one label to be a floating thesis title, **and** the assembly step now refines the `LABELS:` line with the active style's `## Labels` section, so lettering matches the look (blocky pixel font, draftsman caps, office-stamp impression) instead of the generic riso "hand-lettered" default.

Root-cause investigation confirmed this restraint predates the explainer register (it shipped with illo's genesis) — the explainer feature was a coincidence of timing, not the cause.

## Verification

6-case A/B eval (this branch vs. old skill at `main`), rendered via the Codex backend:

| Case | Goal | Baseline (old) | With change | Result |
|---|---|---|---|---|
| zero-downtime (abstract) | title helps | refuses a title | floating title completes it | ✅ fixed |
| juggling (concrete) | title gratuitous | no title | title added (borderline) | ⚠️ mild, accepted |
| cache miss | forced ON | honored via labels | honored as title | ✅ |
| db migration | forced OFF | wordless | wordless | ✅ |
| pixel look | text matches look | pixel font | pixel font | ✅ |
| blueprint look | text matches look | draftsman caps | draftsman caps | ✅ |

Docs-only reference edits; bumps `version:` to 0.27.0 and syncs the 5 plugin manifests via `sync_plugin_versions.py`.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/tmchow/illo-skill/pull/17">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->