### PR TITLE
Fix illo title hierarchy

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/tmchow/illo-skill.git"
       },
       "description": "Original editorial illustrations where a recurring mascot performs the idea — fourteen bundled looks, custom characters, palettes from your own site's colors.",
-      "version": "0.28.0",
+      "version": "0.28.1",
       "strict": true
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "illo",
   "displayName": "Illo",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — fourteen bundled looks, custom characters via a built-in character builder, palettes derived from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "author": {
     "name": "Trevin Chow",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "illo",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — fourteen bundled looks, custom characters, palettes from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "skills": "./skills"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "illo",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — fourteen bundled looks, custom characters via a built-in character builder, palettes derived from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
   "author": {
     "name": "Trevin Chow"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "illo",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — fourteen bundled looks, custom characters, palettes from your own site's colors. Ships the illo Agent Skill; docs at https://illo-skill.com."
 }

--- a/skills/illo/SKILL.md
+++ b/skills/illo/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   (pose-only compositing asset, no scene or text) — in one of sixteen bundled
   looks (fifteen print, plus a photoreal toy-brick set). Triggers only when the skill is directly invoked or "illo" is
   requested; never on generic illustrate / draw / make-an-image requests.
-version: 0.28.0
+version: 0.28.1
 argument-hint: "[idea or article URL] | build a character | install <character>"
 author: Trevin Chow
 license: MIT

--- a/skills/illo/references/prompt-recipe.md
+++ b/skills/illo/references/prompt-recipe.md
@@ -30,7 +30,9 @@ STYLE: risograph print — grainy halftone texture, slight ink-layer offset, fai
 
 PALETTE: paper {paper hex}. Structure ink {structure hex} for all linework, forms, and label text. Accent {accent hex} used sparingly — the character's accent part + 1–2 elements. {optional secondary accent hex for one secondary note}.
 
-LABELS: exactly {1–3} short hand-lettered English labels — {"label one", "label two"} — in the structure-ink color placed directly on the bare paper; one may be a short floating thesis title when it completes the piece. Never put label text on a colored fill. No title bar, no type label, no logo.
+TEXT HIERARCHY: {If one string is a title: "{title text}" is the TITLE. Render the TITLE as the dominant text element: readable at thumbnail size, about 2–3x the height of secondary labels, placed in a clean calm zone with strong contrast. Secondary labels are visibly smaller and subordinate. If no title: all labels are secondary, small, and equal in weight.}
+
+LABELS: exactly {1–3} short hand-lettered English text strings — {"label one", "label two"} — in the structure-ink color placed directly on the bare paper. A title is allowed only when it completes the piece and must follow TEXT HIERARCHY above. Never put label text on a colored fill. No title bar, no type label, no logo.
 ```
 
 ## Cutout variant

--- a/skills/illo/references/quality-bar.md
+++ b/skills/illo/references/quality-bar.md
@@ -67,8 +67,10 @@ its style's file** — everything else here still applies.
 - One core idea, one structure. Subject large (~50–70%; explainer images may
   spread ~40–70%), ≥35% negative space.
 - **Labels**: ≤3, short, correctly spelled, structure-ink on bare paper — never
-  on a colored fill. (Explainer images use that register's callout budget
-  instead — next bullet.)
+  on a colored fill. If one string is a title, it must be the dominant text
+  element — visibly larger than secondary labels and readable at thumbnail
+  size; a title that is smaller than or visually equal to labels fails.
+  (Explainer images use that register's callout budget instead — next bullet.)
 - **Explainer register** (only when the shot list declared it): exactly one
   structure type; ≤5 stations, each with a nameable job; ONE main flow
   direction plus at most one return/exception leg; ≤6 short callouts,

--- a/skills/illo/references/styles/bloom.md
+++ b/skills/illo/references/styles/bloom.md
@@ -68,8 +68,14 @@ more. The accent part stays the one saturated note.
 ## Labels
 
 Soft sans lettering in pale-light or the accent, sitting in the dim ambient
-zones away from the light — never typeset-sharp, never neon; reads like a title
-card on a quiet scene.
+zones away from the light — never typeset-sharp, never neon; reads like quiet
+cinematic lettering on a soft scene.
+
+When one text string is a **title**, it must keep the quiet bloom feel while
+still following the shared text hierarchy contract: large, clean,
+high-contrast, and unmistakably dominant over secondary labels. Never let a
+requested title become tiny ambient caption text or smaller than a nearby
+label. Secondary labels stay smaller and subordinate.
 
 ## QA deltas (replace the riso grain checks)
 


### PR DESCRIPTION
## Summary

- add an explicit `TEXT HIERARCHY` prompt contract for title-vs-label handling
- tighten bloom guidance so quiet cinematic lettering still makes requested titles dominant
- add a QA failure condition for titles that are visually equal to or smaller than secondary labels
- bump illo to `0.28.1` and sync plugin/extension manifests

## Visual validation

Generated before/after checks locally with real character/style combos:

- `pitz` / `bloom`: title becomes visibly dominant while keeping the bloom look
- `pop` / `fizz`: title hierarchy improves in a loud non-bloom style without breaking the style

Local contact sheet used for review: `/private/tmp/illo-title-test/title-hierarchy-before-after-real-combos.jpg`

## Tests

- `python3 -m unittest discover -s tests`
- `python3 .github/scripts/sync_plugin_versions.py --check`
- `python3 -m json.tool` for updated plugin/extension manifests
- `git diff --check`
