### PR TITLE
Improve announcement title hierarchy

### DIFF
--- a/skills/illo/SKILL.md
+++ b/skills/illo/SKILL.md
@@ -228,11 +228,13 @@ Two kinds of input, handled differently:
 - **A URL / article / paste / long post** carries its own context — but
   never generate from the first vivid detail. Route it first
   (`references/composition.md`, "Source routing"): classify the source's
-  **shape and genre**, separate the source's *rhetorical job* from its most
-  drawable detail, **lock the main thesis in one sentence** (a hero locks
-  the source's job, not its loudest evidence — the genre guardrails say what
-  each genre heroes), then pick the coverage — hero, hero + per-section set
-  (the full article job), set, mini-comic, or shot list first. Sets need placements: compact sources (a tweet, one
+  **shape and genre**, infer the **requested artifact's job** (what this
+  image must do for its audience), separate that job from the source's most
+  drawable mechanism, **lock the main thesis in one sentence** (a hero locks
+  the source/artifact job, not its loudest evidence — the genre guardrails
+  say what each genre heroes), then pick the coverage — hero, hero +
+  per-section set (the full article job), set, mini-comic, or shot list
+  first. Sets need placements: compact sources (a tweet, one
   concept) never yield a set — their multi-beat form is the mini-comic. Pull the **load-bearing moments** —
   the few places that turn on a judgment, a loop, an input→output, a
   before/after, or a trap — never one image per paragraph. The text already
@@ -295,10 +297,11 @@ install first, then continue here.
 
 If the user wants planning ("where should this be illustrated", "shot list"),
 output a shot list before generating. Per image: placement, the one idea,
-the register (editorial unless the row passes the explainer gate), the
-staging (or structure type), **what the mascot is doing**, the palette, and
-the short English labels (per-register budgets in
-`references/composition.md`). Let the anchor count drive how many (bands and the never-pad
+the artifact job, the register (editorial unless the row passes the explainer
+gate), the staging (or structure type), **what the mascot is doing**, the
+palette, and the text hierarchy — primary read/title when the artifact needs
+one, plus short supporting labels/callouts within the per-register budgets in
+`references/composition.md`. Let the anchor count drive how many (bands and the never-pad
 rule are in `references/composition.md`). When a stretch of the piece advances
 through stages **in one place**, plan a single mini-comic image there instead
 of several — the mini-comic-vs-separate routing is in
@@ -345,9 +348,9 @@ watermark). QA against the cutout section of `references/quality-bar.md`. Skip
 the editorial shot-list / thesis steps.
 
 **Editorial and explainer.** Build a full prompt per image from
-`references/prompt-recipe.md` (scene +
-structure + style + the active character's spec + resolved palette hexes +
-≤3 labels), write it to a file, and render it. **Pass the active character's
+`references/prompt-recipe.md` (scene + structure + communication hierarchy +
+style + the active character's spec + resolved palette hexes + the
+per-register text budget), write it to a file, and render it. **Pass the active character's
 model sheet as `--ref` every time** — that reference conditioning is what
 keeps the mascot on-model; style and palette come from the prompt, so both
 stays swappable. A pack's sheet is born in its own style, so sheet and style

--- a/skills/illo/references/composition.md
+++ b/skills/illo/references/composition.md
@@ -18,6 +18,16 @@ register only sets which image grammar is allowed.
   callouts — for when the reader must be able to *trace* the structure, not
   just feel it. Rules in "The explainer register" below.
 
+Before choosing the register, infer the **artifact job**: what the requested
+image is supposed to do for its audience in the place it will be seen. This is
+not a keyword match; read the user's intent, destination, and source context.
+Some images are meant to explain a mechanism, but others are meant to introduce,
+promote, frame, or make a new offering legible as a standalone hero/poster. A
+standalone introduction or announcement heroes the role, capability, or
+step-change being claimed; mechanisms from the source become props, secondary
+actions, or small supporting labels. Do not route such an image to explainer
+just because the source contains a traceable process.
+
 Editorial wins every tie. Route an image to explainer only when:
 
 - **(a) the user asks for it** — "show the flow", "diagram the pipeline",
@@ -136,6 +146,12 @@ postmortem · quote · how-to / process · benchmark / comparison · personal
 anecdote · opinion / argument. Genre matters because each one heroes a
 different thing (the **Genre guardrails** below) — the same vivid detail
 that's the headline in one genre is a supporting prop in another.
+Also classify the requested artifact's job: is this image meant to introduce
+the whole thing as a standalone opener/social card, support a section inside a
+piece, explain a mechanism, or provide a reusable visual asset? Let that job
+shape the hero and the text hierarchy. A launch source can contain a process,
+but if the requested artifact is a hero/announcement, the process is evidence
+unless the source's actual promise is the process itself.
 
 **2. Lock the thesis — per coverage unit, not once per piece.** Write one
 sentence before any prompt: *"This image must communicate: \<thesis>."*
@@ -340,16 +356,32 @@ at most one short label per panel.
 
 ## Restraint
 
-- One idea, one staging; ≤3 short labels; leave a calm empty region.
+- One idea, one staging; usually ≤3 short editorial text items total; leave a calm empty region.
   (Explainer images swap these numbers for that register's budget, above —
   everything else here applies to both registers.)
 - A few accent touches — never a colored-in scene.
+- Decide the communication hierarchy before writing the prompt: the **primary
+  read** (the scene alone, or one short floating thesis title) and the
+  **supporting reads** (small labels/callouts that name evidence or parts).
+  Standalone heroes, announcement art, social cards, and abstract claims often
+  need an inferred primary title so the image can be understood away from the
+  surrounding prose. Interior article art often does not.
+- When there is a primary title, reserve its space as a **title field** before
+  placing the subject — usually the calm upper-left or upper-center region in a
+  16:9 hero. The title must sit inside the safe area, with visible paper around
+  it on all sides: roughly one title-letter height, or at least ~6-8% of the
+  canvas, from the nearest frame edge. It is never squeezed against the frame or
+  tucked into a leftover corner. Keep a clear gutter between title, mascot,
+  props, and supporting labels; no tangencies, no crowding, no title touching or
+  visually leaning on the subject.
 - No boxed title bar or diagram-style header, and don't write the staging's
   name. A short *floating* thesis title — a few words on bare paper, like a
-  caption that completes the piece — is fine and counts as one of the labels;
-  reach for it when it lands the idea, skip it when the scene already speaks.
-  Honor an explicit request either way: add a title when the user asks for one,
-  omit it when they say no title.
+  caption that completes the piece — is fine and counts against the editorial
+  text budget; reach for it when it lands the artifact job, skip it when the
+  scene already speaks. If a primary title is present, supporting labels stay
+  visibly subordinate and do not compete with it. Honor an explicit request
+  either way: add a title when the user asks for one, omit it when they say no
+  title.
 
 ## Reinvent each time
 
@@ -371,6 +403,8 @@ and the never-pad rule. Per image:
 - **Idea** — the one sentence it lands: *this anchor's* own thesis-lock
   (Source routing step 2), what this section turns on — not a fragment of
   the piece summary. Each row is analyzed on its own terms.
+- **Artifact job** — opener/social hero, interior section support, mechanism
+  explainer, reusable asset, etc.
 - **Register** — editorial unless the row passes the explainer gate ("Two
   registers"); say which, so the reader can challenge the call.
 - **Staging** — which angle above (editorial), or which structure type
@@ -378,7 +412,10 @@ and the never-pad rule. Per image:
 - **The mascot's move** — the physical action
 - **Object(s)** — the one or two built things
 - **Palette** — preset name or derived dominant
-- **Labels** — the 1–3 short strings
+- **Text hierarchy** — primary read/title if needed, then supporting labels or
+  explainer callouts; keep their visual priority distinct. For a primary title,
+  name the reserved title field and the gutter that keeps it clear of the
+  subject.
 
 Pick the moments that carry the piece — a pivotal claim, a loop, a turn, a trap,
 a handoff — not even coverage across every paragraph. A moment is

--- a/skills/illo/references/prompt-recipe.md
+++ b/skills/illo/references/prompt-recipe.md
@@ -9,8 +9,8 @@ values from `palettes.md`.
 The template below is written for **riso**. When the active character's pack
 declares a different style (its `Style:` line — SKILL.md step 4), replace the
 LINE LANGUAGE and STYLE lines with the blocks from that style's file, build
-the PALETTE line from its palette mapping, refine the LABELS line with the
-style's `## Labels` section so the lettering matches the look (its treatment
+the PALETTE line from its palette mapping, refine the TEXT HIERARCHY line with
+the style's `## Labels` section so the lettering matches the look (its treatment
 and per-look count — e.g. a blocky pixel font, draftsman capitals, an
 office-stamp impression — override the generic "hand-lettered" default), and
 apply its character treatment to the CHARACTER block's value-rule slot.
@@ -20,7 +20,7 @@ apply its character treatment to the CHARACTER block's value-rule slot.
 ```text
 A {aspect, e.g. 16:9 horizontal} editorial illustration that explains ONE idea: "{the single idea}".
 
-Composition ({staging from composition.md}): {the scene — where the mascot is, the move it performs, the one or two built objects, how things flow}. Generous negative space (keep ~35%+ of the canvas empty); the subject is large and confident, ~50–70% of the frame.
+Composition ({staging from composition.md}): {the scene — where the mascot is, the move it performs, the one or two built objects, how things flow}. Generous negative space (keep ~35%+ of the canvas empty); the subject is large and confident, ~50–70% of the frame. {If using a primary title: reserve a clear title field in the calm paper area before placing the subject; keep a generous gutter between the title field, mascot, props, and labels.}
 
 CHARACTER (locked, keep exactly on the reference model): {the active character's prompt spec, with its value rule resolved for this palette}. The mascot is a solid OPAQUE shape in front of the scene — no ground line, table edge, horizon, or prop passes through its body; background lines stop at its silhouette. Its limbs join the body cleanly at sensible points, exactly the count its design specifies (no extra, floating, or mid-body arms/legs). Only the mascot's own parts touch its outline: any tool is HELD in a hand and clearly separated from the torso, or rests in the scene — never pressed flat against the body or sprouting from it. Hold at most one prop per hand; any extra object sits on the table or ground. Preserve the character sheet's limb proportions: a stubby arm stays stubby and nearby, never stretched into a long bar/cable/lever or across the whole scene; handles, horns, tails, ears, or accent carriers are not extra hands unless the character pack explicitly says so.
 
@@ -28,11 +28,15 @@ LINE LANGUAGE: draw EVERYTHING — mascot, objects, arrows — in ONE bold, even
 
 STYLE: risograph print — grainy halftone texture, slight ink-layer offset, faint paper grain, flat fills, no gradients, no soft shadows.
 
-PALETTE: paper {paper hex}. Structure ink {structure hex} for all linework, forms, and label text. Accent {accent hex} used sparingly — the character's accent part + 1–2 elements. {optional secondary accent hex for one secondary note}.
+PALETTE: paper {paper hex}. Structure ink {structure hex} for all linework, forms, and text. Accent {accent hex} used sparingly — the character's accent part + 1–2 elements. {optional secondary accent hex for one secondary note}.
 
-TEXT HIERARCHY: {If one string is a title: "{title text}" is the TITLE. Render the TITLE as the dominant text element: readable at thumbnail size, about 2–3x the height of secondary labels, placed in a clean calm zone with strong contrast. Secondary labels are visibly smaller and subordinate. If no title: all labels are secondary, small, and equal in weight.}
+TEXT HIERARCHY: hand-letter exactly {N} text items in structure ink on bare paper: {optional PRIMARY TITLE: "{short floating thesis title}" — largest and clearest, visually primary, readable at thumbnail size, about 2–3x the height of secondary labels, placed in the reserved title field with visible paper margin around it, at least one title-letter height or ~6-8% of the canvas from the nearest frame edge, and not touching/crowding the mascot or props, with no box/bar/underline; optional SUPPORTING LABELS: {"label one", "label two", "label three"} — smaller, placed near the evidence/parts they name}. Use a primary title when the artifact must read as a standalone hero/announcement/social card or the abstract thesis needs a name; omit it when the scene and surrounding prose already carry the primary read. Editorial text usually stays within 1–3 total items; when a primary title is present, supporting labels stay subordinate and should not compete with it. Never put text on a colored fill. No title bar, no type label, no logo, no extra words.
+```
 
-LABELS: exactly {1–3} short hand-lettered English text strings — {"label one", "label two"} — in the structure-ink color placed directly on the bare paper. A title is allowed only when it completes the piece and must follow TEXT HIERARCHY above. Never put label text on a colored fill. No title bar, no type label, no logo.
+When no embedded text is needed, replace the TEXT HIERARCHY line with:
+
+```text
+TEXT: no hand-lettered text anywhere — no labels, title, caption, logo, signature, numbers, or stray words.
 ```
 
 ## Cutout variant
@@ -88,16 +92,20 @@ Composition (mini-comic, {2–4} panels in ONE image, read left to right, separa
 ## Explainer variant
 
 When the shot list declared the **explainer register** (`composition.md`,
-"The explainer register"), replace the Composition and LABELS lines with the
+"The explainer register"), replace the Composition and TEXT HIERARCHY lines with the
 two below — CHARACTER, LINE LANGUAGE, STYLE, and PALETTE are unchanged, so
 the structure is drawn in the active look. Resolve the semantic ink hexes
 (flow, warning) from `palettes.md` first.
+
+If the artifact job needs a primary announcement/hero read, revisit the
+register gate before using this variant. A true explainer can have callouts,
+but not a title-led hierarchy.
 
 Hex values live in the PALETTE line ONLY — extend it with the semantic-role
 sentence shown below. Never put a hex inside the Composition or CALLOUTS
 lines: a hex adjacent to quoted callout text gets hand-lettered into the art
 as if it were a label. Refer to inks by role name ("the flow color"), exactly
-as the editorial LABELS line refers to "the structure-ink color". When the
+as the editorial TEXT HIERARCHY line refers to "structure ink". When the
 structure has a return/exception leg, state its direction twice — where it
 leaves and where it rejoins — or the model may flip the arrowhead.
 

--- a/skills/illo/references/quality-bar.md
+++ b/skills/illo/references/quality-bar.md
@@ -22,6 +22,12 @@ its style's file** — everything else here still applies.
   incident. Apply the genre guardrails (`composition.md`): does the hero
   match what this genre should hero? If not, **re-route, then re-roll** —
   fix the lock first; do not keep iterating a well-rendered wrong thesis.
+- **Artifact-job test** (especially for standalone heroes/social cards): would
+  a stranger understand what this image is introducing or framing without
+  nearby prose? If the artifact's job is to introduce, announce, promote, or
+  frame a new offering, the primary read must be the role/capability/step-change
+  being claimed. A neat picture of the source's internal mechanism is still a
+  failure when that mechanism is only evidence for the announcement.
 - Correct aspect ratio; the style's expected ground (riso: light paper with
   the risograph grain; other styles: per their QA deltas — e.g. blueprint's
   deep ground is correct).
@@ -66,11 +72,21 @@ its style's file** — everything else here still applies.
   structure-ink (not pure-black) features — not a heavy dark blob.
 - One core idea, one structure. Subject large (~50–70%; explainer images may
   spread ~40–70%), ≥35% negative space.
-- **Labels**: ≤3, short, correctly spelled, structure-ink on bare paper — never
-  on a colored fill. If one string is a title, it must be the dominant text
-  element — visibly larger than secondary labels and readable at thumbnail
-  size; a title that is smaller than or visually equal to labels fails.
+- **Text hierarchy / labels**: editorial text stays short, correctly spelled,
+  structure-ink on bare paper — never on a colored fill. A primary floating
+  title is allowed when the artifact job needs a standalone read; it must be
+  visibly larger than secondary labels and readable at thumbnail size. Supporting
+  labels must remain visibly secondary and not compete with it. If the title
+  and labels flatten into equal-weight callouts, or a title is smaller than or
+  visually equal to labels, re-roll or simplify.
   (Explainer images use that register's callout budget instead — next bullet.)
+- **Title placement** (when a primary title is present): it sits in an
+  intentionally reserved field with visible paper around it, inside the safe
+  area, and separated from the mascot, props, and labels by a clear gutter. Keep
+  it roughly one title-letter height, or at least ~6-8% of the canvas, from the
+  nearest frame edge. If the title feels crammed into a corner, nearly touches
+  the subject/frame, or steals the only calm negative-space region, re-roll with
+  a named title field and a shifted/scaled subject.
 - **Explainer register** (only when the shot list declared it): exactly one
   structure type; ≤5 stations, each with a nameable job; ONE main flow
   direction plus at most one return/exception leg; ≤6 short callouts,
@@ -140,6 +156,12 @@ style QA deltas) still applies to the character cluster.
 ## Fail signals → fix
 
 - A title bar / type label ("Workflow", "System Diagram", "Roadmap") anywhere → edit it out.
+- A standalone announcement/hero image has only mechanism labels and no clear
+  primary read for the thing being introduced → re-route as an editorial hero
+  with a primary title or stronger role/step-change scene, then re-roll.
+- A primary title is technically present but jammed against the edge, clipped,
+  tangent to the subject, or crowding the visual action → re-roll with reserved
+  title space and fewer/smaller supporting labels.
 - Mascot reads as a sticker/cute-cartoon, or shows face details its locked
   design doesn't name (for house-face packs: any mouth/eyebrows/shiny eyes) → re-roll.
 - Looks like a slide, infographic, flowchart, or formal diagram → re-roll


### PR DESCRIPTION
## Summary

Illo now treats standalone announcement and hero art as a communication job, not just a source summary. The skill is guided to infer what the image must do for its audience, reserve a primary title field when the piece needs one, and keep mechanism labels visually subordinate instead of letting them become the whole composition.

This also makes title placement part of QA: a technically present title now fails if it is cramped against the frame, tangent to the subject, or stealing the only calm negative-space region.

## Validation

- Ran `python3 .github/scripts/sync_plugin_versions.py --check`.
- Generated two Codex-backed test renders from the original `ce-pov` announcement prompt using Blip: the first confirmed the new primary-title behavior, and the second tested the reserved title-field guidance that led to the explicit safe-margin rule.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT_5-000000)
