### PR TITLE
feat(grok): add native Grok plugin and marketplace lane

### DIFF
--- a/.github/scripts/sync_plugin_versions.py
+++ b/.github/scripts/sync_plugin_versions.py
@@ -7,10 +7,12 @@ copies it into every plugin manifest that carries a version field:
   .claude-plugin/plugin.json   (Claude Code)
   .codex-plugin/plugin.json    (Codex)
   .cursor-plugin/plugin.json   (Cursor)
+  .grok-plugin/plugin.json     (Grok)
   gemini-extension.json        (Gemini CLI)
 
-plus the illo entry in .claude-plugin/marketplace.json (Claude Code shows
-and updates against the marketplace entry's version).
+plus the illo entry in each marketplace catalog
+(.claude-plugin/marketplace.json, .grok-plugin/marketplace.json), whose
+clients show and update against the marketplace entry's version.
 
 Run with --check to verify everything is in lockstep (exit 1 if not).
 The publish workflow tags releases v<version>, which is what Copilot's
@@ -28,6 +30,7 @@ MANIFESTS = [
     REPO / ".claude-plugin" / "plugin.json",
     REPO / ".codex-plugin" / "plugin.json",
     REPO / ".cursor-plugin" / "plugin.json",
+    REPO / ".grok-plugin" / "plugin.json",
     REPO / "gemini-extension.json",
 ]
 
@@ -43,16 +46,19 @@ def skill_version():
     sys.exit(f"ERROR: no version: in {SKILL_MD} frontmatter")
 
 
-MARKETPLACE = REPO / ".claude-plugin" / "marketplace.json"
+MARKETPLACES = [
+    REPO / ".claude-plugin" / "marketplace.json",
+    REPO / ".grok-plugin" / "marketplace.json",
+]
 
 
 def main():
     version = skill_version()
     check = "--check" in sys.argv
     stale = []
-    for path in MANIFESTS + [MARKETPLACE]:
+    for path in MANIFESTS + MARKETPLACES:
         data = json.loads(path.read_text(encoding="utf-8"))
-        if path == MARKETPLACE:
+        if path in MARKETPLACES:
             target = next(p for p in data["plugins"] if p["name"] == "illo")
         else:
             target = data

--- a/.github/workflows/version-sync.yml
+++ b/.github/workflows/version-sync.yml
@@ -12,6 +12,8 @@ on:
       - ".claude-plugin/marketplace.json"
       - ".codex-plugin/plugin.json"
       - ".cursor-plugin/plugin.json"
+      - ".grok-plugin/plugin.json"
+      - ".grok-plugin/marketplace.json"
       - "gemini-extension.json"
       - ".github/scripts/sync_plugin_versions.py"
   push:

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -1,0 +1,29 @@
+{
+  "name": "illo-skill",
+  "owner": {
+    "name": "Trevin Chow",
+    "url": "https://github.com/tmchow"
+  },
+  "description": "Marketplace for the illo editorial-illustration skill",
+  "plugins": [
+    {
+      "name": "illo",
+      "source": {
+        "type": "local",
+        "path": "."
+      },
+      "description": "Original editorial illustrations where a recurring mascot performs the idea — fourteen bundled looks, custom characters, palettes from your own site's colors.",
+      "version": "0.28.2",
+      "category": "creative",
+      "homepage": "https://illo-skill.com",
+      "keywords": [
+        "illo",
+        "illo skill",
+        "editorial illustration"
+      ],
+      "domains": [
+        "illo-skill.com"
+      ]
+    }
+  ]
+}

--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "illo",
+  "version": "0.28.2",
+  "description": "Original editorial illustrations where a recurring mascot performs the idea — fourteen bundled looks, custom characters, palettes from your own site's colors. Ships the illo Agent Skill and its dual-backend image engine: free generation through your Codex CLI subscription (gpt-image-2) when available, OpenRouter otherwise.",
+  "author": {
+    "name": "Trevin Chow",
+    "url": "https://github.com/tmchow"
+  },
+  "homepage": "https://illo-skill.com",
+  "repository": "https://github.com/tmchow/illo-skill",
+  "license": "MIT",
+  "keywords": [
+    "illo",
+    "illo skill",
+    "editorial illustration"
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,7 +208,7 @@ consequences:
 ## Plugin manifests and version lockstep
 
 The repo doubles as a native plugin/extension for the major runtimes. One
-skill, five manifests, one version:
+skill, six manifests, one version:
 
 - `.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` — Claude
   Code. The repo is its own single-plugin marketplace (`illo@illo-skill`);
@@ -223,6 +223,14 @@ skill, five manifests, one version:
   through the review-gated Cursor Marketplace
   (cursor.com/marketplace/publish); until the listing is approved, Cursor
   users install via the generic skills CLI.
+- `.grok-plugin/plugin.json` + `.grok-plugin/marketplace.json` — Grok (xAI).
+  Grok reads the `.claude-plugin/*` manifests for compat, so illo installs
+  today without these; the native pair makes it a first-class Grok plugin —
+  same rationale as the Codex native file. The marketplace catalog uses a
+  local source (`{"type": "local", "path": "."}`), and its brand-scoped
+  `keywords`/`domains` feed Grok's plugin CTA (kept tight so illo does not
+  mis-fire on generic illustrate requests). This same pair is what the
+  xAI-official-marketplace submission points at (see below).
 - `gemini-extension.json` — Gemini CLI extension; skills auto-discovered
   from `skills/`. (Google is migrating free-tier Gemini CLI users to
   Antigravity CLI, which imports extensions as plugins — the manifest
@@ -246,8 +254,56 @@ back to `github.token`; add a PAT secret only if branch protection requires CI
 to run on Release Please-created PRs.
 
 Before merging layout or manifest changes, validate with the real tools:
-`claude plugin validate .`, `gemini extensions validate .`, and
-`gh skill publish --dry-run`.
+`claude plugin validate .`, `gemini extensions validate .`,
+`grok plugin validate .`, and `gh skill publish --dry-run`.
+
+## Submitting to the xAI plugin marketplace
+
+Getting illo into xAI's official catalog (`xai-org/plugin-marketplace`) is an
+outbound PR to *their* repo — an index that only points at our source, so
+nothing of illo is vendored there. Do this **after** the change you want to
+ship has merged to `main`: the entry pins a commit that must already exist.
+
+1. Fork `xai-org/plugin-marketplace` and branch from `main`.
+2. Get the commit to pin — a full 40-char lowercase SHA; a branch, tag, or
+   short SHA is rejected by their validator:
+   ```bash
+   git ls-remote https://github.com/tmchow/illo-skill.git HEAD
+   ```
+3. Add one entry to their `.grok-plugin/marketplace.json` under `plugins[]`, a
+   remote source pinned to that SHA:
+   ```json
+   {
+     "name": "illo",
+     "description": "Original editorial illustrations where a recurring mascot performs the idea.",
+     "category": "creative",
+     "source": {
+       "source": "url",
+       "url": "https://github.com/tmchow/illo-skill.git",
+       "sha": "<full-40-char-sha-from-step-2>"
+     },
+     "homepage": "https://illo-skill.com",
+     "keywords": ["illo", "illo skill", "editorial illustration"],
+     "domains": ["illo-skill.com"]
+   }
+   ```
+4. Regenerate their component index (never hand-edit it) and validate exactly
+   as their CI does:
+   ```bash
+   python3 scripts/generate-plugin-index.py
+   python3 scripts/validate-catalog.py
+   python3 scripts/generate-plugin-index.py --check
+   ```
+5. Open the PR, fill in their template, and wait for code-owner review.
+
+To roll out a later illo update in their catalog, bump the pinned `sha` in the
+existing entry — never open a second, parallel entry.
+
+Do not confuse this with our own `.grok-plugin/marketplace.json`: that file
+makes this repo directly addable as a Grok marketplace
+(`grok plugin marketplace add tmchow/illo-skill`) and uses a **local** source;
+the xAI entry above lives in *their* repo and uses a **remote** source pinned
+to a SHA.
 
 ## Publishing to ClawHub
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ doesn't have a native lane yet.
 | --- | --- | --- |
 | **Claude Code** | `/plugin marketplace add tmchow/illo-skill` then `/plugin install illo@illo-skill` | `claude plugin update illo`, or enable marketplace auto-update |
 | **Codex** | `codex plugin marketplace add tmchow/illo-skill` then `codex plugin add illo@illo-skill` | `codex plugin marketplace upgrade` |
+| **Grok** | `grok plugin marketplace add tmchow/illo-skill` then `grok plugin install tmchow/illo-skill --trust` | `grok plugin update illo` |
 | **Gemini CLI** | `gemini extensions install https://github.com/tmchow/illo-skill` | `gemini extensions update illo` |
 | **Copilot / GitHub CLI** | `gh skill install tmchow/illo-skill illo` (cross-agent via `--agent`) | `gh skill update illo` |
 | **Hermes** | `hermes skills install tmchow/illo-skill/illo` | `hermes skills update illo` |
@@ -80,8 +81,8 @@ installers copy the entire skill directory verbatim, so the skill dir holds
 only what every install should ship. Docs-only images live in
 `_assets/illo/` (linked by raw URL), and repo meta stays at the root —
 including the plugin manifests (`.claude-plugin/`, `.codex-plugin/`,
-`.cursor-plugin/`, `gemini-extension.json`) that make the repo installable
-as a native plugin on each platform.
+`.cursor-plugin/`, `.grok-plugin/`, `gemini-extension.json`) that make the
+repo installable as a native plugin on each platform.
 
 ## Companion repos
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -34,6 +34,16 @@
         },
         {
           "type": "json",
+          "path": ".grok-plugin/plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".grok-plugin/marketplace.json",
+          "jsonpath": "$.plugins[0].version"
+        },
+        {
+          "type": "json",
           "path": "gemini-extension.json",
           "jsonpath": "$.version"
         }

--- a/skills/illo/README.md
+++ b/skills/illo/README.md
@@ -193,6 +193,7 @@ the fallback for runtimes without a native plugin/skill manager.
 | --- | --- | --- |
 | **Claude Code** | `/plugin marketplace add tmchow/illo-skill` then `/plugin install illo@illo-skill` | `claude plugin update illo`, or enable marketplace auto-update |
 | **Codex** | `codex plugin marketplace add tmchow/illo-skill` then `codex plugin add illo@illo-skill` | `codex plugin marketplace upgrade` |
+| **Grok** | `grok plugin marketplace add tmchow/illo-skill` then `grok plugin install tmchow/illo-skill --trust` | `grok plugin update illo` |
 | **Gemini CLI** | `gemini extensions install https://github.com/tmchow/illo-skill` | `gemini extensions update illo` |
 | **Copilot / GitHub CLI** | `gh skill install tmchow/illo-skill illo` (cross-agent via `--agent`) | `gh skill update illo` |
 | **Hermes** | `hermes skills install tmchow/illo-skill/illo` | `hermes skills update illo` |


### PR DESCRIPTION
## Summary

illo now installs as a first-class **Grok (xAI)** plugin — the sixth native runtime lane alongside Claude Code, Codex, Cursor, Gemini, and Copilot. Grok could already install illo through its `.claude-plugin/*` compat fallback, but xAI's official plugin marketplace wants a native, brand-scoped presence. This adds that presence and lays down the path into their catalog.

What's now possible:

- `grok plugin marketplace add tmchow/illo-skill` then `grok plugin install tmchow/illo-skill --trust` installs the same illo skill natively.
- The new manifests ride the existing version-lockstep machinery, so a release bumps all six lanes together and CI verifies them.
- `AGENTS.md` now carries a turn-key procedure for submitting illo to `xai-org/plugin-marketplace`.

## What changed

- **New `.grok-plugin/` pair** — `plugin.json` (metadata) and `marketplace.json` (single-plugin catalog, local source), mirroring the `.claude-plugin/` pair. Keywords and domains are deliberately tight and brand-scoped so Grok's proactive plugin CTA does not mis-fire on generic "illustrate" requests — consistent with illo's do-not-hijack design.
- **Version lockstep** — the sync script's single-marketplace special case is generalized to a list; both grok files are added to `sync_plugin_versions.py`, `release-please-config.json` extra-files, and the `version-sync` workflow path triggers.
- **Docs** — a Grok row in both README install tables (side by side with the other lanes, never as the only path), `.grok-plugin/` added to the repo-layout paragraph, and a new `AGENTS.md` section documenting the outbound marketplace submission.

### Design decisions

- **Native pair over compat-only.** Grok reads `.claude-plugin/*` for compatibility, so illo installs today without any of this — but a native pair is what qualifies for the official marketplace and controls the CTA metadata. Same rationale that gave Codex and Cursor their own manifests.
- **Local source in our catalog; remote-pinned source in xAI's.** Our own `marketplace.json` uses `{"type": "local", "path": "."}` (verified to surface the plugin); the entry submitted to xAI's repo uses a remote `url` source pinned to a full 40-char commit SHA, per their validator.
- **Outbound PR is deferred, not automated.** It pins a commit that must first exist on `main` and targets a review-gated external repo, so it is captured as a turn-key procedure in `AGENTS.md` rather than opened from here.

## Validation

No app to run — this is manifest, CI, and docs wiring, verified with the real tools:

- `grok plugin validate .` -> valid (1 skill dir discovered); `grok plugin marketplace add` surfaced `illo` as installable at `0.28.2`.
- `python3 .github/scripts/sync_plugin_versions.py --check` -> green; a drift-injection test confirms it catches an out-of-sync grok manifest and repairs it.
- No regression: `claude plugin validate .` and `gh skill publish --dry-run` still pass. (Gemini CLI is not installed locally; `gemini-extension.json` is untouched.)

All grok CLI syntax quoted in the docs was checked against `grok plugin --help` and the installed CLI's bundled docs.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
