### PR TITLE
docs: note Release Please repo-permission setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,6 +253,16 @@ tags. The workflow uses `secrets.RELEASE_PLEASE_TOKEN` when present and falls
 back to `github.token`; add a PAT secret only if branch protection requires CI
 to run on Release Please-created PRs.
 
+**One-time repo setup for the release PR.** Release Please opens its release
+PR, so with the `github.token` fallback the repo must allow Actions to do that:
+Settings → Actions → General → "Allow GitHub Actions to create and approve pull
+requests" must be **on** (API: `can_approve_pull_request_reviews: true`).
+Without it the release job fails at PR creation with "GitHub Actions is not
+permitted to create or approve pull requests" — the workflow itself is fine.
+The scoped alternative, which keeps that toggle off, is to set the
+`RELEASE_PLEASE_TOKEN` PAT secret (contents + pull-requests write); the workflow
+prefers it automatically.
+
 Before merging layout or manifest changes, validate with the real tools:
 `claude plugin validate .`, `gemini extensions validate .`,
 `grok plugin validate .`, and `gh skill publish --dry-run`.


### PR DESCRIPTION
## Summary

Documents the one-time repo setup Release Please needs to open its release PR. The first release-worthy merge (the Grok lane) hit a release-job failure — `GitHub Actions is not permitted to create or approve pull requests` — because the repo's "Allow GitHub Actions to create and approve pull requests" toggle was off and no `RELEASE_PLEASE_TOKEN` was set, so the `github.token` fallback couldn't create the PR. The workflow file was correct; only the account-level setting was missing.

This adds a short "one-time repo setup" note to the Release Please section in `AGENTS.md` so the next fork or clone doesn't rediscover the failure: enable the Actions toggle, or use the scoped `RELEASE_PLEASE_TOKEN` PAT alternative that keeps the toggle off.

Docs-only — no shipped skill content changes, so no release bump.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
