### PR TITLE
fix(codex): detect image backend by image_generation alone

### DIFF
--- a/docs/solutions/integration-issues/codex-image-backend-stale-feature-detection.md
+++ b/docs/solutions/integration-issues/codex-image-backend-stale-feature-detection.md
@@ -1,0 +1,62 @@
+---
+title: Codex image backend silently disabled after upstream removed an experimental feature flag
+date: 2026-07-11
+category: integration-issues
+module: illo-codex-backend
+problem_type: integration_issue
+component: tooling
+symptoms:
+  - "illo silently stopped using the free Codex image backend; every render fell back to OpenRouter/Grok"
+  - "`illo doctor` reported `codex cli: present but not usable` despite a working, logged-in `codex` CLI"
+  - "`codex features list` no longer contained an `imagegenext` row"
+root_cause: wrong_api
+resolution_type: code_fix
+severity: high
+tags: [codex, capability-detection, feature-detection, cli-integration, image-backend, upstream-drift]
+---
+
+# Codex image backend silently disabled after upstream removed an experimental feature flag
+
+## Problem
+illo detects whether the free Codex image backend is usable by parsing `codex features list`. It required **two** rows — the stable `image_generation` feature **and** an experimental `imagegenext` extension. Codex CLI 0.144 removed `imagegenext` (folding its behavior into stable `image_generation`), so detection declared a fully-working, logged-in Codex CLI unusable and every render fell back to OpenRouter (needs an API key) or Grok.
+
+## Symptoms
+- Codex subscribers lost the free image backend with no error — renders quietly used a fallback backend.
+- `illo doctor` printed `codex cli: present but not usable — run codex login, or this host lacks image_generation/imagegenext support` even when logged in.
+- `codex features list` on 0.144 showed `image_generation  stable  true` but no `imagegenext` row at all.
+
+## What Didn't Work
+- **Assuming a bug where `imagegenext` was "missing".** The instinct was that Codex had broken something. It hadn't — `imagegenext` was an experimental extension that got *promoted*: upstream `openai/codex` now ships native artifact handling on the stable feature (`image_generation_artifact_path()`, `ImageGenerationItem.saved_path`), and the experimental flag was deleted once the behavior stabilized. The stable `image_generation` row **was** the replacement, not a peer that lost its partner.
+
+## Solution
+Gate detection on the stable feature alone, and drop the now-dead experimental flag from the generation path.
+
+```python
+# skills/illo/scripts/illo.py — _detect_codex()
+
+# Before: required both rows; the experimental one had just been removed upstream
+low = out.lower()
+if (rc != 0
+        or CODEX_IMAGE_FEATURE not in low
+        or CODEX_IMAGEGEN_EXT_FEATURE not in low):   # <- always True on 0.144
+    return False
+
+# After: the stable feature is the whole capability signal
+if rc != 0 or CODEX_IMAGE_FEATURE not in out.lower():
+    return False
+```
+
+Also removed from `codex_exec_generate()`: the `--enable imagegenext` flag (verified a harmless no-op on 0.144 — `codex -c features.imagegenext=true` exits 0 — but dead), the `CODEX_IMAGEGEN_EXT_FEATURE` constant, and the obsolete `imagegenext` namespace-collision error branch. Updated `doctor` output and `skills/illo/references/backends.md` to match.
+
+## Why This Works
+The artifact-emission behavior `imagegenext` used to force is now intrinsic to the stable `image_generation` feature, so its presence alone proves capability. Verified end-to-end on Codex CLI 0.144.0: `illo doctor` reports `codex cli: usable (logged in, image_generation available)`, and a real `illo generate --backend codex` render produced a genuine gpt-image-2 artifact (`"backend": "codex"`, 1254×1254 PNG) with no flag passed.
+
+## Prevention
+- **Gate capability detection on an upstream tool's STABLE surface, never an experimental / under-development feature flag.** Experimental flags exist to be removed — when the behavior stabilizes, the flag disappears and any check that requires it flips to "unavailable" silently. `codex features list` even labels each row (`stable`, `under development`, `removed`); treat anything but `stable` as ephemeral for gating purposes.
+- **When an experimental flag is added as a workaround, record its removal trigger.** The original code comment said "remove when Codex makes the extension default or replaces it with a stable equivalent" — that condition silently came true. A workaround tied to an upstream state should be re-checked on each upstream version bump, not left indefinitely.
+- **Re-verify third-party-CLI integrations against each new upstream version — detection AND generation, on the real CLI.** A mocked unit test passes forever against a contract the upstream tool has already changed. The test that encoded this bug (`test_detect_codex_requires_imagegenext_row`) faithfully asserted the wrong contract; only a live `features list` + real render caught the drift.
+- **Prefer a live capability probe over a hardcoded feature-name allowlist** when the upstream tool exposes one and the probe is cheap. The narrower the set of exact strings detection depends on, the more brittle it is to upstream renames/removals.
+
+## Related Issues
+- PR: tmchow/illo-skill#32 (the fix)
+- The experimental flag was introduced in an earlier fix ("Fix Codex image artifact generation", commit 51cdbd5) for Codex CLI 0.141 — a workaround that outlived its upstream cause.

--- a/skills/illo/references/backends.md
+++ b/skills/illo/references/backends.md
@@ -88,9 +88,11 @@ does not. The host is "usable Codex" only when **all three** hold:
 
 1. `codex` is on `PATH`;
 2. `codex login status` reports logged in;
-3. `codex features list` reports both `image_generation` and `imagegenext`
-   rows are present. `imagegenext` may be default-disabled; illo enables it per
-   render with `--enable imagegenext`, so presence is the capability signal.
+3. `codex features list` reports the `image_generation` row. Codex 0.144 folded
+   generated-image artifact handling into this stable feature, so its presence is
+   the whole capability signal. (Codex 0.141 also required an experimental
+   `imagegenext` extension to make `codex exec` emit the artifact; that extension
+   was removed once the behavior went stable, so illo no longer gates on it.)
 
 Any non-zero exit, timeout, or unparseable output → not usable, and the
 engine soft-falls to OpenRouter. Detection runs once per process and reads
@@ -124,17 +126,15 @@ enabling Codex.
 
 illo invokes `codex exec` against the built-in tool, attaching the active
 character's reference sheet (`-i <sheet>`) so the mascot stays on-model, and
-asks the agent to save the result to the run-dir path. As of Codex CLI 0.141,
-the stable `image_generation` feature being available is not enough for `exec`
-to expose generated image artifacts reliably; illo also passes
-`--enable imagegenext`. Without that flag the text agent may see the reference
-image and claim it generated an image, while no `$CODEX_HOME/generated_images`
-artifact appears; the agent can then satisfy the requested path with local
-drawing/code, which is not a valid illo render. Keep this flag until Codex
-makes the imagegen extension default or replaces it with a stable equivalent.
-If `imagegenext` hits the known `image_gen` namespace-collision failure
-(openai/codex#28464), illo treats the Codex backend as unavailable and falls
-back to OpenRouter when configured.
+asks the agent to save the result to the run-dir path. As of Codex CLI 0.144
+the stable `image_generation` feature drops the generated artifact under
+`$CODEX_HOME/generated_images` on its own — illo verifies the requested path
+first and otherwise fetches the freshest artifact that postdates the exec.
+(On Codex 0.141 this required an extra `--enable imagegenext` flag, since the
+stable feature did not emit the artifact reliably; the extension was removed
+once the behavior went stable, so illo no longer passes the flag. If a `codex
+exec` run exits non-zero, illo treats the Codex backend as unavailable and
+falls back to OpenRouter when configured.)
 
 With no `--ref` and no
 default character there is nothing to lock to, so illo renders ref-less (a

--- a/skills/illo/scripts/illo.py
+++ b/skills/illo/scripts/illo.py
@@ -95,15 +95,12 @@ CODEX_EXEC_TIMEOUT = 600
 # granularity / clock skew between the wall clock and the file's mtime source.
 CODEX_MTIME_SKEW = 2.0
 # `codex features list` row that means the built-in image tool is reachable.
+# Codex 0.144 folded generated-image artifact handling into this stable feature
+# (see image_generation_artifact_path / ImageGenerationItem.saved_path upstream)
+# and removed the earlier experimental `imagegenext` extension illo used to
+# force artifact emission on 0.141, so this row is now the whole capability
+# signal — `codex exec` drops $CODEX_HOME/generated_images/*.png on its own.
 CODEX_IMAGE_FEATURE = "image_generation"
-# Codex CLI 0.141 exposes generated image artifacts to `codex exec` only when
-# the newer imagegen extension is explicitly enabled. Without this flag, the
-# text agent may see images and even claim it generated one, but no
-# $CODEX_HOME/generated_images/call_*.png artifact appears; the agent may then
-# satisfy the requested output path with local drawing/code, which is not an
-# illo render. Keep this centralized so the flag can be removed when Codex makes
-# the extension default or replaces it with a stable equivalent.
-CODEX_IMAGEGEN_EXT_FEATURE = "imagegenext"
 # Grok backend: `grok -p` is the headless single-turn mode (equivalent of
 # `codex exec`); the agent fires image_gen/image_edit and saves to a path.
 GROK_EXEC_TIMEOUT = 600
@@ -158,11 +155,10 @@ _CODEX_AVAILABLE = None  # per-process cache so detection's subprocesses run onc
 
 def codex_available():
     """True iff the host has a USABLE Codex CLI: `codex` on PATH, logged in, and
-    the built-in image_generation feature plus the imagegenext exec-artifact
-    extension available. Eligibility is a property of the execution host,
-    detected — never assumed. Soft-fails to False on any non-zero exit, timeout,
-    or unparseable output (→ OpenRouter); reads NO credential file and NO
-    secret-shaped env var. Cached per process."""
+    the built-in image_generation feature available. Eligibility is a property of
+    the execution host, detected — never assumed. Soft-fails to False on any
+    non-zero exit, timeout, or unparseable output (→ OpenRouter); reads NO
+    credential file and NO secret-shaped env var. Cached per process."""
     global _CODEX_AVAILABLE
     if _CODEX_AVAILABLE is not None:
         return _CODEX_AVAILABLE
@@ -177,13 +173,9 @@ def _detect_codex():
     rc, out = _codex_run(["login", "status"])
     if rc != 0 or "logged in" not in out.lower():
         return False
-    # Built-in image tool reachable, and the exec image-artifact extension
-    # supported? Both show up as rows in `codex features list`.
+    # Built-in image tool reachable? It shows up as a row in `codex features list`.
     rc, out = _codex_run(["features", "list"])
-    low = out.lower()
-    if (rc != 0
-            or CODEX_IMAGE_FEATURE not in low
-            or CODEX_IMAGEGEN_EXT_FEATURE not in low):
+    if rc != 0 or CODEX_IMAGE_FEATURE not in out.lower():
         return False
     return True
 
@@ -980,7 +972,7 @@ def codex_exec_generate(prompt, refs, out_path):
     privileged action is this subprocess to the user's own CLI."""
     if not codex_available():
         raise BackendUnavailable("Codex CLI not usable (not installed, logged out, "
-                                 "or image_generation/imagegenext unavailable).")
+                                 "or image_generation unavailable).")
     out = pathlib.Path(out_path).resolve()
     run_dir = out.parent
     run_dir.mkdir(parents=True, exist_ok=True)
@@ -993,8 +985,7 @@ def codex_exec_generate(prompt, refs, out_path):
                     f"then save the resulting image to {out} "
                     f"(overwrite if it exists). Do not ask for confirmation.")
     cmd = [_codex_binary(), "exec", "--cd", str(run_dir),
-           "--sandbox", "workspace-write", "--skip-git-repo-check",
-           "--enable", CODEX_IMAGEGEN_EXT_FEATURE]
+           "--sandbox", "workspace-write", "--skip-git-repo-check"]
     # Attach every reference: the active character sheet, plus any finished-look
     # style anchor illo passes for within-set consistency. codex exec -i
     # repeats, so a second --ref is no longer silently dropped.
@@ -1023,12 +1014,6 @@ def codex_exec_generate(prompt, refs, out_path):
     if proc.returncode != 0:
         # Redact before this string can reach a terminal — never echo raw output.
         combined = redact((proc.stdout or "") + (proc.stderr or ""))
-        low = combined.lower()
-        if ("tools.namespace" in low and "image_gen" in low and "collid" in low):
-            raise BackendUnavailable(
-                "codex exec imagegenext namespace collision; this Codex CLI build "
-                "cannot use the Codex image backend reliably. Upgrade Codex "
-                "or use the OpenRouter backend.")
         raise BackendUnavailable(
             f"codex exec exited {proc.returncode}: {combined[:300]}")
     # Verify-first (the agent's save-to-path works under workspace-write), then
@@ -1490,15 +1475,14 @@ def cmd_doctor(args):
                      f"bash {SKILL_DIR / 'scripts/repair-hermes-assets.sh'}")
     else:
         lines.append("assets: OK")
-    # Codex CLI detection — present / logged-in / image_generation + imagegenext,
-    # or why not.
+    # Codex CLI detection — present / logged-in / image_generation, or why not.
     # codex_available() short-circuits at the first failure, so report by stage.
     # Only fall back to a fresh PATH walk when the cached check already said not-usable.
     if codex_ok:
-        lines.append("codex cli: usable (logged in, image_generation + imagegenext available)")
+        lines.append("codex cli: usable (logged in, image_generation available)")
     elif shutil.which("codex"):
         lines.append("codex cli: present but not usable — run `codex login`, "
-                     "or this host lacks image_generation/imagegenext support")
+                     "or this host lacks image_generation support")
     else:
         lines.append("codex cli: not installed (optional — enables free Codex-subscription images)")
     # Grok CLI detection — present + logged in (auth.json exists), or why not.

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -33,7 +33,7 @@ class CodexBackendTests(unittest.TestCase):
     def tearDown(self):
         self.illo.subprocess.run = self.original_run
 
-    def test_codex_exec_enables_imagegenext_and_passes_refs(self):
+    def test_codex_exec_passes_refs_and_does_not_enable_removed_feature(self):
         captured = {}
 
         def fake_run(cmd, input, capture_output, text, timeout):
@@ -60,10 +60,10 @@ class CodexBackendTests(unittest.TestCase):
         self.assertEqual(produced, out_path.resolve())
         self.assertEqual(meta, {"model": None, "id": None})
         cmd = captured["cmd"]
-        self.assertIn("--enable", cmd)
-        enable_index = cmd.index("--enable")
-        self.assertEqual(cmd[enable_index + 1], self.illo.CODEX_IMAGEGEN_EXT_FEATURE)
-        self.assertEqual(self.illo.CODEX_IMAGEGEN_EXT_FEATURE, "imagegenext")
+        # imagegenext was removed in Codex 0.144 (folded into stable
+        # image_generation); illo must no longer enable it.
+        self.assertNotIn("--enable", cmd)
+        self.assertNotIn("imagegenext", cmd)
         self.assertEqual(cmd.count("-i"), 2)
         self.assertIn(str(refs[0]), cmd)
         self.assertIn(str(refs[1]), cmd)
@@ -74,7 +74,7 @@ class CodexBackendTests(unittest.TestCase):
         self.assertTrue(captured["text"])
         self.assertEqual(captured["timeout"], self.illo.CODEX_EXEC_TIMEOUT)
 
-    def test_detect_codex_requires_imagegenext_row(self):
+    def test_detect_codex_accepts_image_generation_alone(self):
         self.illo.shutil.which = lambda name: "/usr/local/bin/codex" if name == "codex" else None
 
         def fake_codex_run(args):
@@ -85,42 +85,20 @@ class CodexBackendTests(unittest.TestCase):
             raise AssertionError(args)
 
         self.illo._codex_run = fake_codex_run
-        self.assertFalse(self.illo._detect_codex())
+        self.assertTrue(self.illo._detect_codex())
 
-    def test_detect_codex_accepts_imagegenext_even_when_default_disabled(self):
+    def test_detect_codex_rejects_when_image_generation_absent(self):
         self.illo.shutil.which = lambda name: "/usr/local/bin/codex" if name == "codex" else None
 
         def fake_codex_run(args):
             if args == ["login", "status"]:
                 return 0, "Logged in using ChatGPT"
             if args == ["features", "list"]:
-                return 0, (
-                    "image_generation stable true\n"
-                    "imagegenext under development false\n"
-                )
+                return 0, "apps stable true\nbrowser_use stable true\n"
             raise AssertionError(args)
 
         self.illo._codex_run = fake_codex_run
-        self.assertTrue(self.illo._detect_codex())
-
-    def test_namespace_collision_is_reported_as_backend_unavailable(self):
-        def fake_run(cmd, input, capture_output, text, timeout):
-            return FakeCompletedProcess(
-                returncode=1,
-                stdout="",
-                stderr=(
-                    "Invalid Value: 'tools.namespace'. User-defined namespace "
-                    "'image_gen' collides with an existing tool namespace."
-                ),
-            )
-
-        with tempfile.TemporaryDirectory() as td:
-            self.illo.subprocess.run = fake_run
-            with self.assertRaises(self.illo.BackendUnavailable) as ctx:
-                self.illo.codex_exec_generate("prompt", [], Path(td) / "out.png")
-
-        self.assertIn("imagegenext namespace collision", str(ctx.exception))
-        self.assertIn("OpenRouter backend", str(ctx.exception))
+        self.assertFalse(self.illo._detect_codex())
 
     def test_generic_codex_error_includes_redacted_combined_output(self):
         fake_secret = "sk-" + "secretvalue123"


### PR DESCRIPTION
## Summary

Codex subscribers with a working, logged-in `codex` CLI silently lost the free Codex image backend: every render fell back to OpenRouter (needs an API key) or Grok. The cause was upstream — Codex CLI 0.144 removed the experimental `imagegenext` feature and folded its `codex exec` artifact-emission behavior into the stable `image_generation` feature. illo's host detection still required the now-removed `imagegenext` row in `codex features list`, so it declared a fully-usable Codex CLI unusable and never selected the backend.

Detection now gates on `image_generation` alone. This also drops the now-dead `--enable imagegenext` flag (a harmless no-op on 0.144, since the stable feature emits the artifact on its own), the `CODEX_IMAGEGEN_EXT_FEATURE` constant, and the obsolete `imagegenext` namespace-collision branch, and updates the `doctor` output and `backends.md` to match.

`imagegenext` was the replacement's predecessor, not a peer: it existed only to force artifact emission on Codex 0.141 before the behavior went stable. Nothing new is required in its place.

## Validation

Verified end-to-end on Codex CLI 0.144.0:

- `codex features list` reports `image_generation` (stable) and no `imagegenext` row.
- `illo doctor` now reports `codex cli: usable (logged in, image_generation available)` (previously "present but not usable … lacks image_generation/imagegenext support").
- A real `illo generate --backend codex` render produced a genuine gpt-image-2 artifact (`"backend": "codex"`, 1254×1254 PNG) — no flag passed.
- `python3 -m py_compile` clean; full test suite 12/12 pass, including the rewritten detection/exec contract tests.

Ships as a `fix:` so Release Please batches the version bump (shipped skill content); no manual `version.txt` / `SKILL.md` edit.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted Codex CLI compatibility fix with updated unit tests; no auth, billing, or OpenRouter path changes.
> 
> **Overview**
> Restores the free Codex image backend on **Codex CLI 0.144**, where upstream removed the experimental `imagegenext` feature and folded artifact emission into stable `image_generation`. illo had still required `imagegenext` in `codex features list`, so logged-in Codex hosts were marked unusable and renders fell back to OpenRouter or Grok.
> 
> **Detection** now treats only the `image_generation` row as the capability signal (`_detect_codex` / `codex_available`). **`codex exec`** no longer passes `--enable imagegenext`; the removed `CODEX_IMAGEGEN_EXT_FEATURE` constant and the special-case **namespace-collision** error path are dropped. **`doctor`** and **`backends.md`** messaging match the slimmer contract. Tests assert detection passes with `image_generation` alone and that exec omits `--enable imagegenext`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3ef349a96c8ebe5e01808c35f64314e9ccf522c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->