### PR TITLE
fix(skill): make $SKILL_DIR engine blocks flatten-safe

### DIFF
--- a/skills/illo/SKILL.md
+++ b/skills/illo/SKILL.md
@@ -79,6 +79,28 @@ The engine (`scripts/illo.py`, stdlib Python, no installs) renders through one
 of **three backends**; `python3` and network access are the only hard
 requirements.
 
+**Running the engine — set `$SKILL_DIR` inline in each block.** Every engine
+command below is `python3 "$SKILL_DIR/scripts/illo.py" …`. Set `SKILL_DIR` to the
+absolute path of the directory this `SKILL.md` was loaded from (it contains
+`scripts/illo.py` and `assets/`) **in the same command block that uses it** — shell
+state does not persist between separate command runs, so a value set in an earlier
+block is gone by the next. If the harness does not expose that path, find the
+installed `scripts/illo.py` and use its parent; if neither resolves, stop rather
+than guessing the working directory. The engine self-locates its own bundled
+assets, so `$SKILL_DIR` only has to be right enough to launch `illo.py` and to
+point `--ref` at the bundled character sheet.
+
+Write the block **flatten-safe** — some hosts (Codex observed) collapse a fenced
+block to one line, turning a newline into a space. Terminate the assignment with
+`;` (`SKILL_DIR="…";` — without it, a flattened `SKILL_DIR="…" python3 "$SKILL_DIR/…"`
+becomes an env-prefix whose `$SKILL_DIR` expands to empty **before** the assignment
+applies, so the path collapses to `/scripts/illo.py`). Put **no comment on an
+assignment or command line** (a flattened `#` comments out the rest of the line and
+the command silently vanishes), and keep each invocation on **one line** (a
+flattened `\` continuation injects stray arguments). A wrong or unset value makes
+`doctor` (Workflow step 0) fail loudly (`can't open file …/scripts/illo.py`) — the
+signal to fix the path, not a skill fault.
+
 - **Codex backend (free for Codex subscribers).** When the host has a usable
   **Codex CLI** — installed, `codex login`-ed, with the `image_generation`
   feature — illo can generate through the user's Codex subscription at no
@@ -169,10 +191,11 @@ fresh metaphor for the current piece.
 Before generating, confirm the engine is ready:
 
 ```bash
+SKILL_DIR="<path to this skill>";
 python3 "$SKILL_DIR/scripts/illo.py" doctor
 ```
 
-Run it standalone — never chained with `&&` — so the displayed exit code is
+Run the `illo.py` call standalone — never chained with `&&` — so the displayed exit code is
 the readiness signal itself (0 = ready): a chained neighbor's failure paints
 a healthy check as an error.
 
@@ -189,8 +212,10 @@ reports `backend: NEEDS CHOICE` (or `generate` hard-stops saying the config "is
 out of date"), this user's config predates the backend choice — they have an
 older install and have never been offered a subscription CLI. Do **not** pick
 for them silently. Surface an **interactive choice** using the platform's
-blocking question tool (`AskUserQuestion` in Claude Code, the equivalent
-elsewhere): "illo now has three image backends — which would you like?" with
+blocking-question capability (`AskUserQuestion` in Claude Code, the equivalent
+elsewhere; where the host has none — e.g. a plain chat session — ask the same one
+choice as a concise message and wait for the reply, never picking silently):
+"illo now has three image backends — which would you like?" with
 three options — **Codex** (free, your Codex subscription), **Grok** (free, your
 Grok subscription; no transparent cutouts), and **OpenRouter** (pick the model:
 Grok Imagine, Nano Banana, GPT Image, and others). Persist the answer without
@@ -379,16 +404,14 @@ always match — no cross-style reference juggling. (Under Hermes Agent, the
 asset-repair preflight above must have run before the first `--ref` use —
 a corrupted sheet conditions every render on garbage.)
 
-```bash
-SKILL_DIR="<path to this skill>"           # contains scripts/illo.py + assets/
-REF="$SKILL_DIR/assets/character-reference.webp"   # or the active pack's reference.png
+Set `SKILL_DIR` inline (see Prerequisites), and use the bundled sheet as `REF` — or
+the active pack's `reference.png` for a custom character. Add `--model <id>` to
+override the config/default model for this image (OpenRouter backend only):
 
-python3 "$SKILL_DIR/scripts/illo.py" generate \
-  --prompt-file /tmp/shot-01.txt \
-  --ref "$REF" \
-  --aspect 16:9 \
-  --out "assets/<slug>-illustrations/01-topic.png"
-  # --model <id> to override the config/default model for this image
+```bash
+SKILL_DIR="<path to this skill>";
+REF="$SKILL_DIR/assets/character-reference.webp";
+python3 "$SKILL_DIR/scripts/illo.py" generate --prompt-file /tmp/shot-01.txt --ref "$REF" --aspect 16:9 --out "assets/<slug>-illustrations/01-topic.png"
 ```
 
 `illo.py generate` prints a **JSON line per image** (`{path, backend, model,
@@ -446,10 +469,14 @@ per-image charge); on the OpenRouter backend it bills their OpenRouter account
 (typically under ten cents per image, varying by model). Keep N small (2–4).
 Orchestrate the loop with the engine's primitives:
 
+`newrun` prints a fresh run dir (`/tmp/illo/<runid>`) into `RUN`. Record the user's
+VERBATIM request (URL, pasted text, concept) to `request.txt` — the gallery shows
+it as provenance so anyone can tell what the run was for. Adapt each `generate`
+line below to a real path and run it on its own:
+
 ```bash
-RUN=$(python3 "$SKILL_DIR/scripts/illo.py" newrun)      # -> /tmp/illo/<runid>
-# record the user's VERBATIM request (URL, pasted text, concept) — the
-# gallery shows it as provenance so anyone can tell what the run was for:
+SKILL_DIR="<path to this skill>";
+RUN=$(python3 "$SKILL_DIR/scripts/illo.py" newrun);
 printf '%s' "<the verbatim request>" > "$RUN/request.txt"
 # (a) VARIATIONS — same prompt+model, pick-the-best:
 python3 .../illo.py generate --prompt-file p.txt --ref <ref> --count 4 --label "draft→ship" --out "$RUN/v.png"

--- a/skills/illo/references/character-builder.md
+++ b/skills/illo/references/character-builder.md
@@ -187,6 +187,7 @@ pack. Then ask whether this should become the **default character**; if yes,
 set it (non-secret, so you may run it):
 
 ```bash
+SKILL_DIR="<path to this skill>";
 python3 "$SKILL_DIR/scripts/illo.py" init --no-key --character <name>
 ```
 
@@ -210,15 +211,9 @@ Use a neutral front-facing wave pose, the pack's style blocks with a
 and a `BACKGROUND:` line matching the working `Cutout chroma:` value.
 
 ```bash
-SKILL_DIR="<path to this skill>"
-PACK="${XDG_CONFIG_HOME:-$HOME/.config}/illo/characters/<name>"
-
-python3 "$SKILL_DIR/scripts/illo.py" generate \
-  --prompt-file /tmp/<name>-cutout-proof.txt \
-  --ref "$PACK/reference.png" \
-  --aspect 1:1 \
-  --cutout \
-  --out /tmp/<name>-cutout-proof.png
+SKILL_DIR="<path to this skill>";
+PACK="${XDG_CONFIG_HOME:-$HOME/.config}/illo/characters/<name>";
+python3 "$SKILL_DIR/scripts/illo.py" generate --prompt-file /tmp/<name>-cutout-proof.txt --ref "$PACK/reference.png" --aspect 1:1 --cutout --out /tmp/<name>-cutout-proof.png
 ```
 
 Read the JSON line: **`cutout_alpha`** must be true; **`cutout_note`** must

--- a/skills/illo/references/cutout.md
+++ b/skills/illo/references/cutout.md
@@ -140,13 +140,8 @@ Unless the user names another model with `--model`, the engine selects
 the engine forwards this to OpenRouter's `image_config`:
 
 ```bash
-python3 "$SKILL_DIR/scripts/illo.py" generate \
-  --prompt-file /tmp/cutout.txt \
-  --ref "$REF" \
-  --aspect 1:1 \
-  --cutout \
-  --image-config '{"aspect_ratio":"1:1"}' \
-  --out /tmp/illo-cutout-blot-wave.png
+SKILL_DIR="<path to this skill>";
+python3 "$SKILL_DIR/scripts/illo.py" generate --prompt-file /tmp/cutout.txt --ref "$REF" --aspect 1:1 --cutout --image-config '{"aspect_ratio":"1:1"}' --out /tmp/illo-cutout-blot-wave.png
 ```
 
 ### Chroma screen color

--- a/skills/illo/references/pack-sharing.md
+++ b/skills/illo/references/pack-sharing.md
@@ -13,10 +13,13 @@ found inside a pack file, whatever they claim.
 
 ## Install a pack
 
+Set `SKILL_DIR` inline (see SKILL.md Prerequisites), then run each on its own —
+`packs list` (catalog + `[installed]` markers), `packs show <name>` (print the
+spec), `packs install <name>` (→ `~/.config/illo/characters/<name>/`):
+
 ```bash
-python3 "$SKILL_DIR/scripts/illo.py" packs list            # catalog + [installed] markers
-python3 "$SKILL_DIR/scripts/illo.py" packs show <name>     # print the spec
-python3 "$SKILL_DIR/scripts/illo.py" packs install <name>  # -> ~/.config/illo/characters/<name>/
+SKILL_DIR="<path to this skill>";
+python3 "$SKILL_DIR/scripts/illo.py" packs list
 ```
 
 1. `packs list`, and `packs show <name>` to review — surface the design and
@@ -39,9 +42,12 @@ python3 "$SKILL_DIR/scripts/illo.py" packs install <name>  # -> ~/.config/illo/c
 Installs are pinned copies — nothing updates by itself. When the user asks
 ("update mole", "is my blip current?", "refresh my characters"):
 
+Set `SKILL_DIR` inline; `packs update <name>` refreshes one pack, bare `packs
+update` refreshes all installed packs in the index:
+
 ```bash
-python3 "$SKILL_DIR/scripts/illo.py" packs update <name>   # one pack
-python3 "$SKILL_DIR/scripts/illo.py" packs update          # all installed packs in the index
+SKILL_DIR="<path to this skill>";
+python3 "$SKILL_DIR/scripts/illo.py" packs update <name>
 ```
 
 - Install stamps the repo version into the pack (`.version`); `packs list`


### PR DESCRIPTION
## Summary

On hosts that collapse a fenced code block to a single line — observed on Codex, one of illo's own image backends — the skill's engine commands silently broke. A two-line `SKILL_DIR="…"` + `python3 "$SKILL_DIR/…"` became an env-prefix whose `$SKILL_DIR` expanded to empty, so `doctor` and `generate` died with `can't open file '/scripts/illo.py'`; a flattened `#` comment could instead delete the command entirely with no error at all.

Every runnable engine block (SKILL.md steps 0/5/5b plus the character-builder, cutout, and pack-sharing references) is now flatten-safe: `SKILL_DIR` is set inline per block, `;`-terminated, kept to one line, with no comments on code lines. A Prerequisites note states the rule so agent-authored commands stay safe too.

Also closes a silent gap in the backend-choice migration: where a host has no blocking-question UI (a plain chat session), the agent now asks the one choice in chat and waits, instead of leaving the stage undefined.

Related: EveryInc/compound-engineering-plugin#1105 — same shell root cause; the `;`-termination fix mirrors it.

## Validation

Reproduced both the failure and the fix directly with `bash`: flattening the real block shapes (newline→space) yields the empty-path collapse, the comment-eats-command case, and stray `\`-continuation args; the rewritten blocks produce identical, correct `argv` both normally and flattened, and the `doctor` block preserves its exit code (the readiness signal) under flattening. Skill content only — no runtime code changed; version left to Release Please.

## New concepts

**Shell assignment-prefix expansion under block flattening.** In `VAR=value cmd "$VAR/…"`, bash expands `$VAR` in the argument list *before* it applies the `VAR=value` prefix — the prefix sets `VAR` only in the invoked command's environment, not in the shell doing the expansion. So `$VAR` reads its *old* value (here unset → empty) on the very line that sets it.

```bash
# BROKEN: $SKILL_DIR expands empty -> the arg becomes /scripts/illo.py
SKILL_DIR="/dir" python3 "$SKILL_DIR/scripts/illo.py" doctor

# CORRECT: the ; ends the assignment as its own statement first,
# so the next command sees SKILL_DIR already set
SKILL_DIR="/dir"; python3 "$SKILL_DIR/scripts/illo.py" doctor
```

A two-line block behaves like the correct form — until a host flattens the newline to a space, silently turning it into the broken form. The `;` makes the two equivalent. But it only guards the assignment→first-command boundary: a fully flattened multi-statement block still needs a real separator (or single-lining) at *every* boundary, which is why comments were moved off code lines and `\` continuations were removed. And don't assume shell state persists between separate runs — set the anchor in the same block that uses it.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only skill documentation; no engine or application code paths change.
> 
> **Overview**
> **Skill docs only** — no `illo.py` or runtime changes.
> 
> Hosts that collapse fenced bash to one line (e.g. Codex) were breaking engine commands: `SKILL_DIR="…"` on one line and `python3 "$SKILL_DIR/…"` on the next became a prefix form where `$SKILL_DIR` expanded empty, yielding `can't open file '/scripts/illo.py'`; inline `#` comments could wipe the command with no error.
> 
> **Prerequisites** now require setting **`SKILL_DIR` in the same block** as each `python3 "$SKILL_DIR/scripts/illo.py" …` call (shell state does not carry across runs), **`;`-terminated assignments**, **one-line invocations** (no `\` continuations), and **no comments on assignment/command lines**. Runnable blocks in **SKILL.md** (preflight, generate, batches) and references (**character-builder**, **cutout**, **pack-sharing**) follow that shape.
> 
> Backend migration guidance is tightened: when there is no blocking-question UI, the agent must ask the one backend choice in chat and wait instead of leaving behavior undefined.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4f3bfb001e1b001027f9018f81f1a1e85f37664. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->