### PR TITLE
feat(illo): add surprise-me / random headless generation mode

### DIFF
--- a/skills/illo/README.md
+++ b/skills/illo/README.md
@@ -231,6 +231,12 @@ kept in lockstep with `SKILL.md` by Release Please and CI.
 - **A single concept** — "illustrate *you are the bottleneck*" → one deadpan
   scene that lands one takeaway. If the idea is thin, it asks a couple of quick
   questions first instead of guessing.
+- **Surprise / random** — "surprise me", "random", or scoped variants like
+  "surprise me with art quote using bray": invents or fetches a safe, shareable
+  saying (inspirational, educational, or interesting — not a two-word stub),
+  including warm topical hooks when they fit, picks a random installed
+  character unless named, and returns one image plus that caption-ready line.
+  Built for casual prompts and scheduled agents alike.
 - **Mini-comics** — a process, a before→after, a fail→fix told in 2–4 panels
   inside one image. The best shape when a sequence belongs together — and for
   social, where one self-contained image beats a thread.

--- a/skills/illo/SKILL.md
+++ b/skills/illo/SKILL.md
@@ -64,7 +64,7 @@ infographic, not a formal flowchart, not a UI mockup.
 |---|---|
 | **Illustrate an article / post / newsletter / URL** | Steps 0–7: route the source first (thesis → coverage: hero / hero+set / set / mini-comic — `references/composition.md`, "Source routing"), then shot list (hero row + anchors), one image per anchor, interleave by placement. |
 | **One image for a single concept** | Step 1 concept branch (up to ~3 quick questions if the idea is thin), then a single image. |
-| **Surprise / random** — "surprise me", "random", "surprise me with art quote using bray" | Read `references/surprise.md` in full, then Steps 0 + 2–7 as one headless image: invent or fetch a safe **saying** (sense-bar originals; multi-source verified citations only), pick register with deliberate variety, random installed character unless named, deliver saying + image. Poster titles default off; mini-comics still get per-panel labels. |
+| **Surprise / random** — "surprise me", "random", "surprise me with art quote using bray" | Read `references/surprise.md` in full (character + register resolved there — ignore `defaultCharacter`), then Steps 0 + 3–7 as one headless image: invent or fetch a safe **saying** (sense-bar originals; multi-source verified citations only), deliver saying + image. Poster titles default off; mini-comics still get per-panel labels. |
 | **A sequence — process, before→after, fail→fix** | One **mini-comic** when the progression sits in one place (shape routing in `references/composition.md` — the idea picks the shape, the destination never does). |
 | **A traceable structure** — "show the flow", "diagram the pipeline", "map the steps", "as an explainer" | The **explainer register** (`references/composition.md`, "The explainer register"): a hand-built flow / fan-out / timeline / loop / stack / system slice in the active look, the mascot a working part of it. Also reachable without the phrases when a unit's thesis IS the structure (the register gate). |
 | **Social-ready art for X posts / article body images** | 16:9 (or 1:1 when square is explicitly useful), bold `ink-punch`, watermark with the `x` handle if configured or asked. |
@@ -278,8 +278,10 @@ Three kinds of input, handled differently:
 
 - **Surprise / random** ("surprise me", "random", "surprise me with art quote
   using bray", and close variants) — the ask is invent-and-render, not a
-  supplied thesis. **Stop and read `references/surprise.md` in full**, then
-  continue Steps 0 + 2–7 as one headless image. Do not enter the thin-concept
+  supplied thesis. **Stop and read `references/surprise.md` in full**, resolve
+  character and register there (ignore `defaultCharacter`; random when
+  unnamed), then continue Steps 0 + 3–7 as one headless image — Step 2 is
+  skipped because the pack is already chosen. Do not enter the thin-concept
   Q&A path below. A prompt that already names a concrete idea
   ("illustrate 'you are the bottleneck'") is **not** surprise mode even if
   it also says "surprise me".
@@ -317,6 +319,10 @@ Three kinds of input, handled differently:
   the answer is obvious from context. Never block a clear request by asking.
 
 ### 2. Resolve the character
+
+**Surprise / random mode:** skip this step — character was already resolved
+in `references/surprise.md` (named pack, or random among installed + Blot;
+never `defaultCharacter`). Continue at Step 3+.
 
 Installed packs live under `${XDG_CONFIG_HOME:-~/.config}/illo/characters/`
 (format and location details: `references/character.md`); `doctor` lists

--- a/skills/illo/SKILL.md
+++ b/skills/illo/SKILL.md
@@ -6,12 +6,15 @@ description: >-
   explainer diagram (a flow, fan-out, timeline, loop, or stack) when the
   structure itself is the point, or a transparent character cutout
   (pose-only compositing asset, no scene or text) — in one of sixteen bundled
-  looks (fifteen print, plus a photoreal toy-brick set). Triggers only when the skill is directly invoked or "illo" is
-  requested; never on generic illustrate / draw / make-an-image requests.
+  looks (fifteen print, plus a photoreal toy-brick set). Also handles
+  "surprise me" / "random" (optionally scoped to a focus or character): invents
+  or fetches a safe seed idea and renders one headless image. Triggers only
+  when the skill is directly invoked or "illo" is requested; never on generic
+  illustrate / draw / make-an-image requests.
 # x-release-please-start-version
 version: 0.30.0
 # x-release-please-end
-argument-hint: "[idea or article URL] | build a character | install <character>"
+argument-hint: "[idea or article URL] | build a character | install <character> | surprise me [focus] [using character]"
 author: Trevin Chow
 license: MIT
 metadata:
@@ -61,6 +64,7 @@ infographic, not a formal flowchart, not a UI mockup.
 |---|---|
 | **Illustrate an article / post / newsletter / URL** | Steps 0–7: route the source first (thesis → coverage: hero / hero+set / set / mini-comic — `references/composition.md`, "Source routing"), then shot list (hero row + anchors), one image per anchor, interleave by placement. |
 | **One image for a single concept** | Step 1 concept branch (up to ~3 quick questions if the idea is thin), then a single image. |
+| **Surprise / random** — "surprise me", "random", "surprise me with art quote using bray" | Read `references/surprise.md` in full, then Steps 0 + 2–7 as one headless image: invent or fetch a safe **saying** (sense-bar originals; multi-source verified citations only), pick register with deliberate variety, random installed character unless named, deliver saying + image. Poster titles default off; mini-comics still get per-panel labels. |
 | **A sequence — process, before→after, fail→fix** | One **mini-comic** when the progression sits in one place (shape routing in `references/composition.md` — the idea picks the shape, the destination never does). |
 | **A traceable structure** — "show the flow", "diagram the pipeline", "map the steps", "as an explainer" | The **explainer register** (`references/composition.md`, "The explainer register"): a hand-built flow / fan-out / timeline / loop / stack / system slice in the active look, the mascot a working part of it. Also reachable without the phrases when a unit's thesis IS the structure (the register gate). |
 | **Social-ready art for X posts / article body images** | 16:9 (or 1:1 when square is explicitly useful), bold `ink-punch`, watermark with the `x` handle if configured or asked. |
@@ -172,6 +176,7 @@ Do not load everything at once. Pull the file that matches the step:
 - `references/palettes.md` — named presets, default resolution, custom palettes, **and the derive-a-palette-from-one-color algorithm**. Read in full before choosing or deriving any palette.
 - `references/composition.md` — the two registers (editorial scene / explainer diagram) and the explainer's structure types and budget, stagings, turning an idea into a move, the no-recycled-composition rule, and the shot-list format.
 - `references/cutout.md` — the cutout register: transparent compositing assets, contact continuity, pose vocabulary, and generate flags. Read in full before any cutout request.
+- `references/surprise.md` — surprise / random mode: scope parse, random character, saying bar + sense bar, deliberate register variety, poster titles off but mini-comic panel labels on, multi-source quote verification, safety filter, headless contract. Read in full before any surprise/random request.
 - `references/backends.md` — the three-backend image engine: how the backend resolves (precedence Codex > Grok > OpenRouter, and the self-identify rule), the Codex/Grok CLI requirements, the built-in image tool being automatic (no model selection), quota-vs-charge, Grok's no-cutout limit, Windows/WSL, and OpenRouter as the universal fallback. Read before choosing or explaining a backend.
 - `references/models.md` — the model lineup (**OpenRouter backend only**): friendly-name → OpenRouter id map, traits, aspect caveats, 404/fallback handling. Read before passing any `--model`.
 - `references/prompt-recipe.md` — the generation prompt template and the edit/recolor prompts.
@@ -269,8 +274,15 @@ never copy it.
 
 ### 1. Read the input — and clarify a thin concept (briefly)
 
-Two kinds of input, handled differently:
+Three kinds of input, handled differently:
 
+- **Surprise / random** ("surprise me", "random", "surprise me with art quote
+  using bray", and close variants) — the ask is invent-and-render, not a
+  supplied thesis. **Stop and read `references/surprise.md` in full**, then
+  continue Steps 0 + 2–7 as one headless image. Do not enter the thin-concept
+  Q&A path below. A prompt that already names a concrete idea
+  ("illustrate 'you are the bottleneck'") is **not** surprise mode even if
+  it also says "surprise me".
 - **A URL / article / paste / long post** carries its own context — but
   never generate from the first vivid detail. Route it first
   (`references/composition.md`, "Source routing"): classify the source's
@@ -301,9 +313,8 @@ Two kinds of input, handled differently:
     follows the idea, never the destination (`references/composition.md`).
 
   Keep it to **one short round**, then proceed. **Skip the questions entirely**
-  if the user already gave enough, said "just make it" / "single shot" /
-  "surprise me", or the answer is obvious from context. Never block a clear
-  request by asking.
+  if the user already gave enough, said "just make it" / "single shot", or
+  the answer is obvious from context. Never block a clear request by asking.
 
 ### 2. Resolve the character
 

--- a/skills/illo/references/surprise.md
+++ b/skills/illo/references/surprise.md
@@ -33,15 +33,27 @@ Surprise mode is always headless:
 - Still run Step 0 preflight. If `doctor` reports `backend: NEEDS CHOICE`,
   surface that choice — it is a hard blocker, not a taste question.
 
+## Procedure order
+
+Execute in this order — do not invent the saying before the register is
+chosen:
+
+1. Parse scopes → resolve **character** (below)
+2. Pick **register** (below)
+3. Find / invent the **saying** shaped to earn that register
+4. Apply the **safety filter**, then lock the **thesis**
+5. Render via Steps 0 + 3–7 (skip Step 2 — character is already resolved)
+
 ## Parse scopes
 
 Strip the trigger words, then split what remains into **character** and
 **focus**:
 
 1. **Character** — phrases like `using blot`, `with bray`, `as blip`.
-   Resolve with Step 2 rules (pack name → aliases → catalog). On one clear
-   match, use it; on several, pick the closest name match without asking; on
-   none, say the name was unknown and fall through to random.
+   Resolve by pack name → aliases → catalog (same matching rules as Step 2;
+   do **not** fall through to `defaultCharacter`). On one clear match, use
+   it; on several, pick the closest name match without asking; on none, say
+   the name was unknown and fall through to random.
 2. **Focus** — everything else that scopes subject matter: `art quote`,
    `productivity`, `space`, `cooking`, `design`, etc. Unscoped = any safe
    domain.
@@ -54,9 +66,38 @@ character list, then **add shipped `blot`** if it is not already present.
 Pick **uniformly at random** (e.g. a one-liner over the name list). Name
 the chosen pack in the delivery text.
 
+## Register variety (pick before the saying)
+
+Surprise runs must **not** collapse into the same picture shape every time
+(one mascot + one prop + a big title). Pick the **register first**, then
+shape the saying and thesis to earn it — do not invent a single-beat claim
+and then default to editorial every run.
+
+Choose among these with deliberate variety across runs (and within a
+scheduled series). A simple rotation works: editorial → mini-comic →
+explainer → editorial… unless the user's focus forces a shape (e.g. "as a
+comic", "show the flow"):
+
+- **Editorial** — one caught scene. Still the most common, but not automatic.
+- **Mini-comic** — 2–4 panels in one image when the saying is a short
+  progression (stuck → try → land; closed → open → light). Invent the saying
+  so it *has* beats — do not demote a progression into a single freeze-frame.
+  Panel lettering follows the house mini-comic rules below (not silence).
+- **Explainer** — a hand-built flow / fan-out / timeline / loop / stack when
+  the saying teaches a structure (how care compounds, how a craft works, how
+  an archive becomes a discovery). Invent the saying so the structure *is*
+  the point — then follow `references/composition.md`, "The explainer
+  register", including short station callouts.
+- **Never cutout** — cutouts carry no idea.
+
+If the chosen register and a candidate saying fight each other, rewrite the
+saying or pick a different register — do not silently fall back to
+editorial+title.
+
 ## Seed discovery — three layers
 
-There is **no** canned topic bank. Build three related pieces, then render:
+There is **no** canned topic bank. With register already chosen, build three
+related pieces, then render:
 
 | Layer | Role | Lives where |
 |---|---|---|
@@ -173,6 +214,9 @@ or verification fails.
 
 ### How to find the saying
 
+Shape every candidate for the **register already chosen** (beats for
+mini-comic, structure for explainer, single stake for editorial):
+
 1. Prefer a **fresh, drawable moment** with a human stake — then either find
    a **verifiable** sourced line that fits it, or write an **original**
    saying that passes the sense bar (no citation).
@@ -194,14 +238,14 @@ or verification fails.
    with **no** citation — do not fake a famous voice. Illustrate the *idea*,
    not a wall of text on the canvas.
 5. Reject sayings that cannot become a **physical move the mascot performs**
-   (`references/composition.md`, "Turn the idea into a move"). Abstract
-   vibes without a move → invent a concrete staging, then rewrite the
-   saying so it still names the stake.
+   (`references/composition.md`, "Turn the idea into a move") in the chosen
+   register. Abstract vibes without a move → invent a concrete staging, then
+   rewrite the saying so it still names the stake.
 
 Re-roll until the saying clears the saying bar, the sense bar (for
 originals / paraphrases), the safety filter, **and** has a named physical
-move (plus a verified citation whenever a name is attached). Never "tone
-down" a banned topic into the picture.
+move that fits the chosen register (plus a verified citation whenever a name
+is attached). Never "tone down" a banned topic into the picture.
 
 ## Safety filter
 
@@ -222,34 +266,6 @@ achievements, nature, learning, collaboration.
 **Borderline current events:** keep only the **celebratory or wondrous**
 face (the launch succeeded; the discovery landed) — never the controversy
 around it. If unsure whether a seed is safe, invent something else.
-
-## Register variety (pick before locking the move)
-
-Surprise runs must **not** collapse into the same picture shape every time
-(one mascot + one prop + a big title). Pick the **register first**, then
-shape the saying and thesis to earn it — do not invent a single-beat claim
-and then default to editorial every run.
-
-Choose among these with deliberate variety across runs (and within a
-scheduled series). A simple rotation works: editorial → mini-comic →
-explainer → editorial… unless the user's focus forces a shape (e.g. "as a
-comic", "show the flow"):
-
-- **Editorial** — one caught scene. Still the most common, but not automatic.
-- **Mini-comic** — 2–4 panels in one image when the saying is a short
-  progression (stuck → try → land; closed → open → light). Invent the saying
-  so it *has* beats — do not demote a progression into a single freeze-frame.
-  Panel lettering follows the house mini-comic rules below (not silence).
-- **Explainer** — a hand-built flow / fan-out / timeline / loop / stack when
-  the saying teaches a structure (how care compounds, how a craft works, how
-  an archive becomes a discovery). Invent the saying so the structure *is*
-  the point — then follow `references/composition.md`, "The explainer
-  register", including short station callouts.
-- **Never cutout** — cutouts carry no idea.
-
-If the chosen register and a candidate saying fight each other, rewrite the
-saying or pick a different register — do not silently fall back to
-editorial+title.
 
 ## Thesis lock
 
@@ -286,9 +302,10 @@ lettering.
   requires (`composition.md`); still no poster title above the diagram.
 - Never hand-letter the full saying onto the image.
 
-Then continue with Steps 2–7 as a **single** image (character already
-resolved above; Step 2 is confirmation, not re-asking). Explainer and
-mini-comic rows still follow those registers' shot-list / structure rules.
+Then continue with Steps 0 + 3–7 as a **single** image (character already
+resolved above — skip Step 2 so `defaultCharacter` cannot override).
+Explainer and mini-comic rows still follow those registers' shot-list /
+structure rules.
 
 ## Delivery
 

--- a/skills/illo/references/surprise.md
+++ b/skills/illo/references/surprise.md
@@ -1,0 +1,307 @@
+# Surprise mode
+
+Invent or fetch a **safe** seed idea, lock one thesis, and render **one**
+image through the normal workflow — with **no clarifying questions**. Built
+for both casual "surprise me" prompts and scheduled / headless agents that
+call the skill on a timer and need a caption-ready deliverable back.
+
+Read this file in full before acting on any surprise / random request.
+
+## When to route here
+
+Route here when the ask is essentially **unscoped invent-and-render**:
+
+- "surprise me", "surprise", "illo surprise"
+- "random", "random illo", "give me something random"
+- scoped variants: "surprise me with art quote", "random using blot",
+  "surprise me with space using bray"
+
+**Do not** route here when the user already supplied a concrete thesis
+("illustrate 'you are the bottleneck'", "draw the bridge under live
+traffic"). Those stay the Step 1 concept branch — "just make it" / "single
+shot" only skips questions; they are not surprise mode.
+
+## Headless contract
+
+Surprise mode is always headless:
+
+- **Never** ask clarifying questions (focus, destination, shape, palette).
+- **Never** fan out into option batches (`--count`, model loops) unless the
+  user explicitly asked for options.
+- Always **one** image.
+- Resolve palette via normal Step 4 defaults (no destination interrogation).
+- Still run Step 0 preflight. If `doctor` reports `backend: NEEDS CHOICE`,
+  surface that choice — it is a hard blocker, not a taste question.
+
+## Parse scopes
+
+Strip the trigger words, then split what remains into **character** and
+**focus**:
+
+1. **Character** — phrases like `using blot`, `with bray`, `as blip`.
+   Resolve with Step 2 rules (pack name → aliases → catalog). On one clear
+   match, use it; on several, pick the closest name match without asking; on
+   none, say the name was unknown and fall through to random.
+2. **Focus** — everything else that scopes subject matter: `art quote`,
+   `productivity`, `space`, `cooking`, `design`, etc. Unscoped = any safe
+   domain.
+
+### Character when unnamed
+
+Ignore config `defaultCharacter` in this mode (surprise means variety;
+explicit names still win). Build the pool from `doctor`'s installed
+character list, then **add shipped `blot`** if it is not already present.
+Pick **uniformly at random** (e.g. a one-liner over the name list). Name
+the chosen pack in the delivery text.
+
+## Seed discovery — three layers
+
+There is **no** canned topic bank. Build three related pieces, then render:
+
+| Layer | Role | Lives where |
+|---|---|---|
+| **Saying** | The shareable caption — the line a person posts *with* the image | Delivery text (always) |
+| **Provenance** | Citation only when sourced and multi-source verified; omit when original or unverified | Delivery text when citing |
+| **Thesis** | One sentence naming what the picture must communicate | Internal lock before the prompt |
+| **Title** (optional) | A short on-image label that helps the scene read at a glance | Pixels, only when useful |
+
+The saying is the load-bearing deliverable for scheduled / share use. The
+thesis turns that saying into a physical move. Cite only when there is a
+real source — silence means original. The title is never a substitute for
+the saying.
+
+### Saying bar (reject thin stubs)
+
+Ask: *Would this line still earn a pause if the image were covered?* If not,
+re-roll the saying before locking a thesis.
+
+A good saying is a **complete thought** with impact — roughly one to three
+sentences, or one dense sentence with a turn — that is at least one of:
+
+- **inspirational** — warmth, courage, patience, quiet pride
+- **educational** — a real insight you could teach in a breath
+- **interesting** — a vivid observation, gentle wit, or wonder (topical
+  science and craft count)
+
+Hard reject as a saying (these may still be *titles*):
+
+- Two-to-four-word stubs: "The spike settles", "Roll again", "First light"
+- Jargon shorthand with no human stake: "check once", "steep", "provision"
+- Vague mood without a claim: "be kind", "keep going", "stay curious"
+
+Thin → rich (shape only — invent fresh lines every run; do not reuse these):
+
+- ✗ "The spike settles." → ✓ "Rough patches peak. Hold steady and the bolt
+  gets smaller — the storm was never meant to be the whole sky."
+- ✗ "First light." → ✓ "After years of building the ruler, the instrument
+  finally saw Earth — first light is the moment craft becomes witness."
+- ✗ "Steep." → ✓ "A pause is part of the work: what ships well was allowed
+  to steep."
+
+Famous / recalled quotes still work when they already clear the bar; invent
+original sayings when the focus is unscoped or topical — then run the
+**sense bar** below before locking. Cite only when sourced (next section).
+Never imply a line is a famous quote when it is not.
+
+### Sense bar (critical evaluation — especially originals)
+
+Fluent is not the same as true or useful. Models often emit lines that
+*sound* wise and mean little, contradict themselves, or invent fake
+profundity. Before locking any **original** saying (and before locking an
+inspired-by paraphrase of a topical hook), run this judgment out loud in
+planning — reject and rewrite on any fail:
+
+1. **Plain-sense test** — Restate the claim in plain words with no metaphor.
+   If you cannot, or the restatement is empty ("be mindful of journeys"),
+   reject.
+2. **Stake test** — Name who benefits and what changes if the claim is
+   taken seriously. If nobody would act differently, reject.
+3. **Non-contradiction** — The line must not undo itself or stack opposing
+   advice without a clear turn. Reject vibes that cancel out.
+4. **Specificity** — Prefer a concrete domain (craft, rest, learning,
+   noticing, repair) over cosmic filler. Reject abstract fog sold as depth.
+5. **Honest originality** — Do not smuggle a half-remembered famous quote
+   as an "original." If it might be someone else's line, verify or rewrite
+   until it is clearly yours.
+6. **Share test** — Would you post this under the image without cringing or
+   needing a footnote to explain what you meant? If not, reject.
+
+Attributed quotes that already passed verification skip this bar (their
+authors own the claim). Still reject a verified quote that fails the
+ordinary saying bar (too thin, unsafe, undrawable).
+
+### Provenance (cite when sourced)
+
+Every saying is either **sourced** or **original**. Cite only when sourced —
+do not add an `— original` marker; omission of a citation is enough.
+
+1. **Attributed quote** — a real line from a real person / work. Prefer this
+   when the focus is quote-shaped (`art quote`, `design quote`, …) or when a
+   well-known safe line already clears the saying bar. Delivery form:
+   `"{saying}" — Name` (add work/year only when it helps).
+   **Verification gate (required before citing):**
+   - Do **not** trust model memory alone — LLMs commonly invent or
+     misattribute quotes.
+   - Do **not** cite from a single blog, quote-aggregator, or social post.
+   - Confirm with **at least two independent reputable sources**, and prefer
+     a primary or near-primary one when available (the person's published
+     work, a scholarly edition, a museum/archive transcript, a
+     well-regarded quotation reference that cites the original). Quote-
+     investigator sites (e.g. Quote Investigator) count as one strong
+     check when they document the trail.
+   - The wording must match closely enough to be honest — do not "improve"
+     a quote and keep the name.
+   - If sources disagree, the trail is murky, or only viral lists agree:
+     **do not attribute**. Deliver as an original (no citation) or pick a
+     different, verifiable line.
+2. **Attributed idea / topical hook** — not a verbatim quote, but grounded
+   in a real event, discovery, or named practice (e.g. a science first-light,
+   a craft tradition). Delivery form: the saying, then a short credit line
+   such as `Inspired by …` / `After …` naming the source. Confirm the event
+   against a reputable report (agency release, major news, paper) — not a
+   single unverified post. Keep the credit factual and celebratory (safety
+   filter still applies).
+3. **Original** — invented for this run. Fair game, and common for unscoped
+   surprise — **only after the sense bar passes**. Deliver the saying alone
+   — **no** fake author, **no** `— original` tag. Lack of citation is the
+   signal.
+
+**Never** invent a fake author, misattribute a line, or dress an original as
+a classic. Prefer (1) or (2) when share-credibility matters **and** the
+verification gate passes; use (3) freely when inventing is the honest path
+or verification fails.
+
+### How to find the saying
+
+1. Prefer a **fresh, drawable moment** with a human stake — then either find
+   a **verifiable** sourced line that fits it, or write an **original**
+   saying that passes the sense bar (no citation).
+2. **May fetch** (web search, news, pop culture) when the focus invites
+   topicality, or when the run is unscoped and a safe current hook is
+   available — a successful rocket launch, a science discovery, a sports
+   celebration, a museum opening, a harmless meme shape. Historical
+   knowledge and famous quotes remain fair game **only after verification**.
+   Compress the hook into a saying that teaches or wonders, not a headline
+   stub; run the sense bar on any paraphrase; cite only when the provenance
+   gate passes.
+3. **May invent or recall** when fetch is unavailable, empty, or every
+   topical candidate fails the safety filter — originals must clear the
+   sense bar and carry no citation; a recalled quote still must pass
+   verification before any name is attached.
+4. For **quote-shaped** focuses (`art quote`, `design quote`, …): prefer a
+   **verified attributed** line that clears the saying bar. If verification
+   fails, invent an original quote-shaped line that clears the **sense bar**
+   with **no** citation — do not fake a famous voice. Illustrate the *idea*,
+   not a wall of text on the canvas.
+5. Reject sayings that cannot become a **physical move the mascot performs**
+   (`references/composition.md`, "Turn the idea into a move"). Abstract
+   vibes without a move → invent a concrete staging, then rewrite the
+   saying so it still names the stake.
+
+Re-roll until the saying clears the saying bar, the sense bar (for
+originals / paraphrases), the safety filter, **and** has a named physical
+move (plus a verified citation whenever a name is attached). Never "tone
+down" a banned topic into the picture.
+
+## Safety filter
+
+Apply **before** locking the thesis.
+
+**Allow:** warmth, quiet joy, curiosity, craft / making, gentle absurdity,
+playful point-of-view disagreement that stays kind, celebration of safe
+achievements, nature, learning, collaboration.
+
+**Hard reject:**
+
+- Politics, elections, parties, policy fights, wars, geopolitics
+- Race, ethnicity, religion-as-conflict, identity attacks
+- Tragedy, disaster aftermath, crime, medical trauma, death
+- Sexual content, cruelty, humiliation, "roast" / cutting humor
+- Culture-war bait, conspiracy, harassment
+
+**Borderline current events:** keep only the **celebratory or wondrous**
+face (the launch succeeded; the discovery landed) — never the controversy
+around it. If unsure whether a seed is safe, invent something else.
+
+## Register variety (pick before locking the move)
+
+Surprise runs must **not** collapse into the same picture shape every time
+(one mascot + one prop + a big title). Pick the **register first**, then
+shape the saying and thesis to earn it — do not invent a single-beat claim
+and then default to editorial every run.
+
+Choose among these with deliberate variety across runs (and within a
+scheduled series). A simple rotation works: editorial → mini-comic →
+explainer → editorial… unless the user's focus forces a shape (e.g. "as a
+comic", "show the flow"):
+
+- **Editorial** — one caught scene. Still the most common, but not automatic.
+- **Mini-comic** — 2–4 panels in one image when the saying is a short
+  progression (stuck → try → land; closed → open → light). Invent the saying
+  so it *has* beats — do not demote a progression into a single freeze-frame.
+  Panel lettering follows the house mini-comic rules below (not silence).
+- **Explainer** — a hand-built flow / fan-out / timeline / loop / stack when
+  the saying teaches a structure (how care compounds, how a craft works, how
+  an archive becomes a discovery). Invent the saying so the structure *is*
+  the point — then follow `references/composition.md`, "The explainer
+  register", including short station callouts.
+- **Never cutout** — cutouts carry no idea.
+
+If the chosen register and a candidate saying fight each other, rewrite the
+saying or pick a different register — do not silently fall back to
+editorial+title.
+
+## Thesis lock
+
+With register and saying locked, write one composition sentence before any
+prompt:
+
+> This image must communicate: \<thesis>.
+
+The thesis is the *move* (or panel beats / structure type) compressed from
+the saying — not a shorter substitute for the saying. Example: saying = a
+rough-patch paragraph; mini-comic thesis = "panel 1 bolt wild → panel 2
+mascot steadies it → panel 3 bolt small and calm."
+
+## On-image text — no poster title; comics still letter
+
+In surprise mode the **saying already lives in delivery**, so a big
+floating **primary title** is usually redundant and makes every run look
+like the same poster. That ban is about *poster titles*, not about all
+lettering.
+
+- **Default across registers: no PRIMARY TITLE.** Do not put STEEP / ONE STEP
+  / FIRST LIGHT style headlines on the canvas.
+- **Editorial** — usually `TEXT: no hand-lettered text`, or at most 1–2 tiny
+  supporting labels if a prop must be named. Never a poster title.
+- **Mini-comic** — **letter the panels by default.** Follow
+  `references/composition.md` / `prompt-recipe.md`: at most **one short
+  label per panel** (a beat word, a whisper of dialogue, a caption, or a
+  sound) on bare paper/ground inside or beside that panel. Compress the
+  saying into those beats — do not dump the full saying as a title above
+  the strip. A fully wordless comic is allowed only when the silent
+  progression is clearer than any label; it is the exception, not the
+  habit.
+- **Explainer** — short station/callout labels as the explainer budget
+  requires (`composition.md`); still no poster title above the diagram.
+- Never hand-letter the full saying onto the image.
+
+Then continue with Steps 2–7 as a **single** image (character already
+resolved above; Step 2 is confirmation, not re-asking). Explainer and
+mini-comic rows still follow those registers' shot-list / structure rules.
+
+## Delivery
+
+Always report, next to the image (path or chat media per Step 7):
+
+- the **saying** first — full shareable caption
+- a **citation** only when sourced **and verified** — `— Name` for quotes
+  (after the multi-source gate), or `Inspired by …` / `After …` for topical
+  hooks confirmed against a reputable report. Omit any credit line when the
+  saying is original or attribution is unverified.
+- the **character** used
+- palette / look only as briefly as a normal single-image delivery
+
+Do not deliver only the on-image title or a thesis stub. Scheduled callers
+need caption text without OCR — the saying (and citation when sourced) is
+part of the deliverable, not optional commentary.


### PR DESCRIPTION
## Summary

Agents can now run illo in **surprise / random** mode without a user brief: invent or safely fetch a seed idea, pick character and register, then generate one headless image with a shareable caption. That unblocks scheduled and cron use where nobody is there to supply a topic.

The methodology lives in `references/surprise.md` (wired from `SKILL.md` + a README capability bullet). No engine changes—agents follow the reference, then the normal generate path. Design choices baked in after gallery validation:

- **Saying bar + sense bar** — captions must be complete, shareable thoughts; originals get a critical pass before ship
- **Honest provenance** — cite only verified sources; omit attribution for originals (no `— original` marker)
- **Register variety** — rotate editorial / mini-comic / explainer; mini-comics letter panels by default
- **Character** — random among installed packs (+ Blot); ignore `defaultCharacter` in this mode

## Test plan

- [ ] Trigger with “surprise me” / “random illo” and confirm routing to surprise mode (no brief interview)
- [ ] Confirm optional character/focus scoping still works when named
- [ ] Spot-check captions: saying bar, provenance honesty, register rotation across a few runs
- [ ] Confirm headless delivery (one image, no follow-up questions)

## Evidence

Validation galleries from iterative surprise runs:

- Register variety: https://4ca6c16c.ht-ml.app/
- Panel labels + citations: https://e59120c6.ht-ml.app/

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![HARNESS](https://img.shields.io/badge/Cursor_Grok_4.5-000000)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Skill and reference documentation only; no changes to `illo.py` or generation backends, so runtime behavior is unchanged unless agents follow the new instructions.
> 
> **Overview**
> Adds **surprise / random** mode so agents can invent a safe seed idea and render **one headless image** with a **caption-ready saying**—aimed at casual prompts and scheduled runs without a user brief.
> 
> New **`references/surprise.md`** defines the full procedure: scope parsing (optional focus + `using <character>`), random character among installed packs (+ Blot, ignoring `defaultCharacter`), register rotation (editorial / mini-comic / explainer), saying and sense bars, multi-source quote verification, safety filter, no clarifying questions, and delivery that leads with the saying (poster titles off; mini-comic panel labels on).
> 
> **`SKILL.md`** and **`README.md`** wire routing: read `surprise.md`, skip Step 2 character resolution, run Steps 0 + 3–7; concrete thesis prompts are explicitly **not** surprise mode even if they say “surprise me.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 675c5cdd338466453751f1603af132cdda60591c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->