### PR TITLE
fix(codex): enrich plugin install metadata

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -2,5 +2,40 @@
   "name": "illo",
   "version": "0.31.0",
   "description": "Original editorial illustrations where a recurring mascot performs the idea — fourteen bundled looks, custom characters, palettes from your own site's colors. Ships the illo Agent Skill and its three-backend image engine: free generation through your Codex or Grok CLI subscription when available, OpenRouter otherwise.",
-  "skills": "./skills"
+  "author": {
+    "name": "Trevin Chow",
+    "url": "https://github.com/tmchow"
+  },
+  "homepage": "https://illo-skill.com",
+  "repository": "https://github.com/tmchow/illo-skill",
+  "license": "MIT",
+  "keywords": [
+    "illustration",
+    "editorial",
+    "image-generation",
+    "mascot",
+    "riso"
+  ],
+  "skills": "./skills",
+  "interface": {
+    "displayName": "illo",
+    "shortDescription": "Editorial illustrations with consistent characters",
+    "longDescription": "Create original editorial illustrations, explainers, mini-comics, and transparent character cutouts in distinctive bundled print looks. Build reusable characters, derive palettes from a site, and render through Codex, Grok, or OpenRouter.",
+    "developerName": "Trevin Chow",
+    "category": "Creative",
+    "capabilities": [
+      "Image Generation",
+      "Image Editing",
+      "Character Design"
+    ],
+    "websiteURL": "https://illo-skill.com",
+    "defaultPrompt": [
+      "Use illo to create an editorial illustration for this article.",
+      "Use illo to turn this concept into a mascot-led visual metaphor.",
+      "Use illo to build a reusable character for future illustrations."
+    ],
+    "brandColor": "#F46FB5",
+    "composerIcon": "./_assets/illo/logo/illo-logo-avatar.png",
+    "logo": "./_assets/illo/logo/illo-logo.png"
+  }
 }


### PR DESCRIPTION
## Summary

Codex plugin surfaces can now present illo as a branded, discoverable product instead of a bare skill package. Publisher details, character-consistency positioning, starter prompts, and the existing logo assets give users clearer context before install and useful starting points afterward; the version remains untouched for Release Please to advance across every runtime manifest in lockstep.

## Validation

- Codex plugin manifest validator with pinned PyYAML 6.0.2 — passed
- JSON parsing and `git diff --check` — passed

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000?logoColor=white)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only change to the Codex plugin JSON; no application logic or security-sensitive behavior is modified.
> 
> **Overview**
> Expands the Codex **`.codex-plugin/plugin.json`** manifest so install/discovery surfaces can show illo as a branded product instead of a minimal skill pointer.
> 
> Adds **publisher and package metadata** (`author`, `homepage`, `repository`, `license`, `keywords`) and a new **`interface`** block with display copy, Creative category, capabilities, starter **`defaultPrompt`** lines, brand color, and logo/composer icon paths. **`version`** stays at `0.31.0` so Release Please can bump manifests in lockstep elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bf64211a3ad547e44897d784cf3f02da5e8c728. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->