### PR TITLE
fix(codex): sharpen plugin starter prompts

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -30,9 +30,9 @@
     ],
     "websiteURL": "https://illo-skill.com",
     "defaultPrompt": [
-      "Use illo to create an editorial illustration for this article.",
-      "Use illo to turn this concept into a mascot-led visual metaphor.",
-      "Use illo to build a reusable character for future illustrations."
+      "surprise me",
+      "illustrate 'many inputs become one decision'",
+      "install all character packs and describe them to me"
     ],
     "brandColor": "#F46FB5",
     "composerIcon": "./_assets/illo/logo/illo-logo-avatar.png",


### PR DESCRIPTION
Codex now presents task-shaped starter prompts that showcase three distinct illo entry points: surprise generation, a concrete concept illustration, and community character-pack installation. The prompts follow Codex's composer convention by omitting redundant “Use illo…” framing, keeping each option direct and scannable.

Validation passed with `python3 -m json.tool .codex-plugin/plugin.json`, `claude plugin validate .`, `grok plugin validate .`, and `gh skill publish --dry-run`. `gemini extensions validate .` could not run because the Gemini CLI is not installed in this environment.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only change to Codex plugin starter strings; no runtime, auth, or image pipeline logic is touched.
> 
> **Overview**
> Updates the Codex plugin’s **`defaultPrompt`** list so composer starters are shorter and task-shaped instead of repeating “Use illo to…”.
> 
> The three options now highlight distinct entry points: open-ended **surprise me** generation, a concrete concept (**illustrate 'many inputs become one decision'**), and **install all character packs and describe them to me** for community packs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4104465075f8f5a833f6994df1f76614d42367f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->