### PR TITLE
fix(illo): trust artifacts and gate paid fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ and reference-image character consistency. Renders through **three backends**:
 your **Codex CLI** (gpt-image-2) or **Grok CLI** (xAI) on your subscription —
 free for subscribers, no API key — when one is installed and logged in, or
 **OpenRouter** (model-selectable: Grok Imagine, Nano Banana 2/Pro, GPT-5.4
-Image 2, …) as the universal fallback. Grok can't make transparent cutouts;
-those fall back automatically.
+Image 2, …) as a direct pay-per-image backend. Failed subscription renders
+fail closed unless `--allow-paid-fallback` explicitly permits OpenRouter.
+Grok can't make transparent cutouts; those route automatically.
 
 Hand it *"we replatform with zero downtime"* and you get the bridge being
 rebuilt under live traffic:

--- a/skills/illo/README.md
+++ b/skills/illo/README.md
@@ -100,11 +100,13 @@ network access are the only hard requirements:
   Grok agent. Two limits: no model selection, and **no transparent cutouts**
   (Grok returns JPEG with no alpha) — cutouts auto-fall back to Codex or
   OpenRouter.
-- **OpenRouter (the universal fallback).** An
+- **OpenRouter (paid, direct or explicit fallback).** An
   **[OpenRouter](https://openrouter.ai) API key** lets illo call OpenRouter's
-  image API directly — the path on any host without a subscription CLI, and the
-  fallback when one is unavailable. **Model-selectable** — see
-  [Models & cost](#models--cost) below.
+  image API directly — the path on a host without a subscription CLI.
+  **Model-selectable** — see [Models & cost](#models--cost) below. A failed
+  Codex/Grok render never spends money automatically: pass
+  `--allow-paid-fallback` to explicitly permit that pay-per-image retry.
+  Intentional cutout routing remains automatic.
 
 ### Setting the key (OpenRouter path)
 

--- a/skills/illo/SKILL.md
+++ b/skills/illo/SKILL.md
@@ -117,12 +117,14 @@ signal to fix the path, not a skill fault.
   quota. Same env-free, token-free subprocess design as Codex. **Grok returns
   JPEG with no alpha, so it cannot make transparent cutouts** — those auto-fall
   back to a cutout-capable backend. The image tool exposes no model selector.
-- **OpenRouter backend (the universal fallback).** Needs an **OpenRouter API
-  key** in the user's config file — the **single credential channel** —
-  written once by the user-run `init` (mode 600). The engine never reads
-  secrets from the environment and never accepts them as command-line
-  arguments. This is the path on any host without a subscription CLI, and the
-  fallback when one fails. It is **model-selectable** (`--model`).
+- **OpenRouter backend (paid, direct or explicit fallback).** Needs an
+  **OpenRouter API key** in the user's config file — the **single credential
+  channel** — written once by the user-run `init` (mode 600). The engine never
+  reads secrets from the environment and never accepts them as command-line
+  arguments. A host without a subscription CLI can select this path directly.
+  A failed Codex/Grok render does **not** spend money automatically: paid
+  fallback requires `--allow-paid-fallback`. It is **model-selectable**
+  (`--model`).
 
 Capsule of the backend model (resolution and precedence, the CLI requirements,
 the built-in image tool being automatic, quota vs. charge, cutout limits,
@@ -177,7 +179,7 @@ Do not load everything at once. Pull the file that matches the step:
 - `references/composition.md` — the two registers (editorial scene / explainer diagram) and the explainer's structure types and budget, stagings, turning an idea into a move, the no-recycled-composition rule, and the shot-list format.
 - `references/cutout.md` — the cutout register: transparent compositing assets, contact continuity, pose vocabulary, and generate flags. Read in full before any cutout request.
 - `references/surprise.md` — surprise / random mode: scope parse, random character, saying bar + sense bar, deliberate register variety, poster titles off but mini-comic panel labels on, multi-source quote verification, safety filter, headless contract. Read in full before any surprise/random request.
-- `references/backends.md` — the three-backend image engine: how the backend resolves (precedence Codex > Grok > OpenRouter, and the self-identify rule), the Codex/Grok CLI requirements, the built-in image tool being automatic (no model selection), quota-vs-charge, Grok's no-cutout limit, Windows/WSL, and OpenRouter as the universal fallback. Read before choosing or explaining a backend.
+- `references/backends.md` — the three-backend image engine: how the backend resolves (precedence Codex > Grok > OpenRouter, and the self-identify rule), the Codex/Grok CLI requirements, artifact-first success, the built-in image tool being automatic (no model selection), quota-vs-charge, Grok's no-cutout limit, Windows/WSL, and opt-in paid fallback. Read before choosing or explaining a backend.
 - `references/models.md` — the model lineup (**OpenRouter backend only**): friendly-name → OpenRouter id map, traits, aspect caveats, 404/fallback handling. Read before passing any `--model`.
 - `references/prompt-recipe.md` — the generation prompt template and the edit/recolor prompts.
 - `references/quality-bar.md` — the post-generation checklist and iteration rules. Read before delivering.
@@ -440,7 +442,10 @@ CLI-served record (Codex or Grok). `cost` is null unless `--cost` is passed —
 Read `.path` — it may differ from `--out`: the engine names the file by the
 actual encoding (some models return JPEG bytes, so a requested `.png` lands
 as `.jpg`). Use `.width/.height` to catch a square when 16:9 was requested
-(re-roll).
+(re-roll). A failed Codex/Grok render stops by default even when an OpenRouter
+key is configured. Add `--allow-paid-fallback` only when the user has explicitly
+approved a pay-per-image retry. Direct `--backend openrouter` renders and the
+intentional Grok-cutout redirect remain direct routes and do not need this flag.
 Generate each image **separately** — never combine ideas into one canvas. Default
 aspect is 16:9; use `1:1` for square social, `9:16`/`4:5` for vertical, and
 `1536:640` for an **X Article banner / hero**. For X Article banners, the

--- a/skills/illo/references/backends.md
+++ b/skills/illo/references/backends.md
@@ -14,8 +14,10 @@ file; they differ only in where the image is made and who is billed.
   (Grok returns JPEG with no alpha) — cutout renders redirect to a
   cutout-capable backend.
 - **OpenRouter** — calls OpenRouter's image API directly. Pay-per-image
-  through the user's OpenRouter account. The **universal fallback** and the
-  only backend a host without a subscription CLI can use.
+  through the user's OpenRouter account. The direct paid backend and the only
+  backend a host without a subscription CLI can use. A failed CLI render reaches
+  it only when `--allow-paid-fallback` is explicitly supplied; intentional
+  cutout routing is unchanged.
 
 `--backend` (and config `backend:`) selects one explicitly; otherwise the
 engine resolves the right one by host capability. Resolution and readiness
@@ -94,10 +96,13 @@ does not. The host is "usable Codex" only when **all three** hold:
    `imagegenext` extension to make `codex exec` emit the artifact; that extension
    was removed once the behavior went stable, so illo no longer gates on it.)
 
-Any non-zero exit, timeout, or unparseable output → not usable, and the
-engine soft-falls to OpenRouter. Detection runs once per process and reads
-**no** credential file and **no** secret-shaped env var. `doctor` reports
-the stage that failed (`codex login` needed, feature unavailable, etc.).
+Any non-zero detection exit, timeout, or unparseable output means Codex is not
+usable. The capability-aware default can then select Grok or direct OpenRouter.
+Once Codex is selected for a render, generation fails closed by default;
+OpenRouter retry requires `--allow-paid-fallback`. Detection runs once per
+process and reads **no** credential file and **no** secret-shaped env var.
+`doctor` reports the stage that failed (`codex login` needed, feature
+unavailable, etc.).
 
 If the user needs to enable it: install the official Codex CLI and run
 `codex login` — that is the entire setup. illo never touches the token.
@@ -128,13 +133,17 @@ illo invokes `codex exec` against the built-in tool, attaching the active
 character's reference sheet (`-i <sheet>`) so the mascot stays on-model, and
 asks the agent to save the result to the run-dir path. As of Codex CLI 0.144
 the stable `image_generation` feature drops the generated artifact under
-`$CODEX_HOME/generated_images` on its own — illo verifies the requested path
-first and otherwise fetches the freshest artifact that postdates the exec.
-(On Codex 0.141 this required an extra `--enable imagegenext` flag, since the
-stable feature did not emit the artifact reliably; the extension was removed
-once the behavior went stable, so illo no longer passes the flag. If a `codex
-exec` run exits non-zero, illo treats the Codex backend as unavailable and
-falls back to OpenRouter when configured.)
+`$CODEX_HOME/generated_images/<session-id>/<image>.png` on its own — illo
+verifies the requested path first and otherwise fetches the freshest valid image
+artifact at that fixed depth that postdates the exec. (On Codex 0.141 this
+required an extra `--enable imagegenext` flag, since
+the stable feature did not emit the artifact reliably; the extension was removed
+once the behavior went stable, so illo no longer passes the flag.) Artifact
+presence takes precedence over wrapper status: Codex can complete
+`image_generation` and persist the PNG, then exit 1 because its final assistant
+text is empty. A valid requested or fresh generated artifact is still a Codex
+success, including after a timeout; only a run with no valid fresh artifact
+fails.
 
 With no `--ref` and no
 default character there is nothing to lock to, so illo renders ref-less (a
@@ -146,25 +155,24 @@ the only privileged action is the subprocess call to the user's own CLI
 (the one sanctioned exception to the stdlib-over-subprocess rule — a benign
 call to a known CLI, not a credential read). The adapter verifies the file
 landed, otherwise fetches the
-freshest image the tool dropped under `$CODEX_HOME/generated_images/`
+freshest image the tool dropped under
+`$CODEX_HOME/generated_images/<session-id>/`
 (`$CODEX_HOME` resolved at run time — relocatable, never hardcoded).
 
-### Windows/WSL is unsupported → OpenRouter
+### Windows/WSL is unsupported
 
 `codex exec` image generation is broken on Windows/WSL (openai/codex#19133).
-illo treats that as a backend failure and falls over to OpenRouter when a key
-is configured.
+illo treats that as a backend failure. Select OpenRouter directly, or explicitly
+permit the paid retry with `--allow-paid-fallback` when a key is configured.
 
 ### Fallback behavior
 
-When the Codex backend is unavailable or fails for **any** non-fatal reason —
-no usable CLI, `codex exec` errored or timed out, unsupported platform, or no
-retrievable image — illo:
-
-- falls back to **OpenRouter** when a key is configured (the manifest record
-  is tagged `backend: openrouter`); or
-- exits with a clear, actionable error naming both fixes (install +
-  `codex login`, or run `init` to set an OpenRouter key) when no key is set.
+When the Codex backend is unavailable or produces no valid fresh artifact, illo
+**fails closed by default**, even when an OpenRouter key is configured. It falls
+back to OpenRouter only when the caller explicitly supplies
+`--allow-paid-fallback`; that paid record is tagged `backend: openrouter`.
+Direct `--backend openrouter` generation is not a fallback and does not need the
+flag.
 
 A Codex-served record carries `cost: null` and no model id, and the engine
 never queries OpenRouter for its cost.
@@ -185,11 +193,12 @@ The host is "usable Grok" when **both** hold:
 Detection reads the credential file's **existence only, never its contents**
 (scanner-clean: no secret read, no secret-shaped env var — `$GROK_HOME` is a
 path, not a secret). The image tools' reachability can't be probed without a
-billed call, so a logged-out or image-ineligible account **soft-fails at
-generate time** (→ fallback), not at detection. Detection runs once per process
-and soft-falls to the next backend on any miss. `doctor` reports whether the CLI
-is usable, present-but-logged-out, or absent. Setup is the entire story:
-install the Grok CLI and run `grok login`.
+billed call, so a logged-out or image-ineligible account fails at generation
+time rather than detection. The capability-aware default can choose the next
+available backend when Grok is not detectable; once a Grok render starts, paid
+OpenRouter retry is opt-in. Detection runs once per process. `doctor` reports
+whether the CLI is usable, present-but-logged-out, or absent. Setup is the entire
+story: install the Grok CLI and run `grok login`.
 
 ### The image tool is automatic — no model selection
 
@@ -208,7 +217,9 @@ key color — so chroma-keying fails (opaque corners, heavy fringe). illo does
 **not** attempt cutouts on Grok: a `--cutout` render whose backend resolves to
 `grok` **redirects** to a cutout-capable backend — Codex if usable, else
 OpenRouter GPT Image 2 if a key is set — and prints a note; with neither it
-exits naming both fixes. The manifest records the backend that actually ran.
+exits naming both fixes. This pre-render capability redirect is intentional and
+does not require `--allow-paid-fallback`. The manifest records the backend that
+actually ran.
 
 ### Quota, transport, and character lock
 
@@ -227,19 +238,19 @@ file landed, else fetches the freshest image the tool dropped under
 
 ### Fallback behavior
 
-When the Grok backend is unavailable or fails for **any** non-fatal reason — no
-usable CLI, `grok` errored or timed out, or no retrievable image — illo falls
-back to **OpenRouter** when a key is configured (record tagged
-`backend: openrouter`), or exits naming both fixes (`grok login`, or `init` to
-set an OpenRouter key) when no key is set. A Grok-served record carries
-`cost: null` and no model id.
+When the Grok backend is unavailable or produces no retrievable image, illo
+**fails closed by default**, even with a configured OpenRouter key. It retries
+through OpenRouter only when `--allow-paid-fallback` is explicitly supplied
+(record tagged `backend: openrouter`). A Grok-served record carries `cost: null`
+and no model id.
 
 ## OpenRouter backend
 
 The pay-per-image path, billed to the user's OpenRouter account. It is
 **model-selectable** (`--model`; see `references/models.md` for the lineup,
-the friendly-name → id map, the aspect caveat, and 404/fallback handling), is
-the universal fallback for any host where a subscription CLI is unavailable, and
-is the redirect target for cutouts when the resolved backend is Grok. Its wire
-behavior is unchanged from a single-backend install — the multi-backend work
-is purely additive.
+the friendly-name → id map, the aspect caveat, and 404/fallback handling).
+Use it directly with `--backend openrouter` without any fallback flag. It is also
+the capability-aware default on a host with a configured key and no usable
+subscription CLI, the explicit paid retry target after a failed CLI render, and
+the intentional redirect target for Grok cutouts. Its wire behavior is unchanged
+from a single-backend install.

--- a/skills/illo/references/quality-bar.md
+++ b/skills/illo/references/quality-bar.md
@@ -38,6 +38,13 @@ its style's file** — everything else here still applies.
   exactly (house default: two dot eyes, blank deadpan, no brow, no mouth),
   every locked part present, locked treatments reading in aggregate, one
   accent carrier, nothing the spec doesn't name.
+  - **Pack-driven face-interior scan:** when the active character pack forbids a
+    mouth, muzzle divider, cheek, nostril, or any other interior facial mark,
+    inspect a tight face crop at full resolution and judge literal strokes, not
+    the intended expression. After accounting for explicitly locked eyes/marks,
+    any prohibited line, loop, notch, arc, divider, or construction stroke inside
+    the face is a **hard fail**. Do not rationalize it as anatomy, texture, or a
+    route/prop line; ambiguous marks fail and must be edited or re-rolled.
 - **Structural integrity** — a separate axis from "on-model" (a body can be
   perfectly on-model and still be assembled wrong, so the identity check
   above will not catch this; scan for it deliberately). The one rule that
@@ -65,7 +72,13 @@ its style's file** — everything else here still applies.
     or sprouting from it. Watch the case where the mascot is given more
     props than it has hands: the extra one tends to fuse to the torso — keep
     held props to **one per hand** and let any others rest in the world.
-  - **In mini-comics, run all three checks on every panel separately** —
+  - **Line topology / collisions** — trace facial strokes and every route-like
+    line (wire, arrow, path, ground line, cable) through contacts near the
+    character. A stroke must keep one clear owner and readable endpoints. It is a
+    hard fail when a facial or route stroke visually fuses into a face, torso, or
+    limb, creates apparent extra anatomy, or makes a limb and route read as one
+    continuous line. Restore a clear gap/occlusion or re-roll.
+  - **In mini-comics, run all four checks on every panel separately** —
     each panel is its own small render and the repeated, smaller mascot
     instances are where these errors drift in most.
 - **Value matches the palette**: in light palettes the body is light with
@@ -163,7 +176,9 @@ style QA deltas) still applies to the character cluster.
   tangent to the subject, or crowding the visual action → re-roll with reserved
   title space and fewer/smaller supporting labels.
 - Mascot reads as a sticker/cute-cartoon, or shows face details its locked
-  design doesn't name (for house-face packs: any mouth/eyebrows/shiny eyes) → re-roll.
+  design doesn't name → inspect the tight face crop and re-roll. For a pack that
+  forbids facial interior marks, any mouth-like loop/line, cheek/muzzle/nostril
+  mark, or construction stroke is a hard fail regardless of apparent intent.
 - Looks like a slide, infographic, flowchart, or formal diagram → re-roll
   simpler. (In the explainer register the fail is *formality* — vector-clean
   boxes, a legend, a grid, a boxed title — not the presence of arrows and

--- a/skills/illo/scripts/illo.py
+++ b/skills/illo/scripts/illo.py
@@ -99,7 +99,8 @@ CODEX_MTIME_SKEW = 2.0
 # (see image_generation_artifact_path / ImageGenerationItem.saved_path upstream)
 # and removed the earlier experimental `imagegenext` extension illo used to
 # force artifact emission on 0.141, so this row is now the whole capability
-# signal — `codex exec` drops $CODEX_HOME/generated_images/*.png on its own.
+# signal — `codex exec` drops
+# $CODEX_HOME/generated_images/<session-id>/<image>.png on its own.
 CODEX_IMAGE_FEATURE = "image_generation"
 # Grok backend: `grok -p` is the headless single-turn mode (equivalent of
 # `codex exec`); the agent fires image_gen/image_edit and saves to a path.
@@ -117,9 +118,9 @@ SECRET_RE = re.compile(r"\b(sk-[A-Za-z0-9_-]{8,}|eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-
 class BackendUnavailable(Exception):
     """A backend could not produce an image for a non-fatal reason (Codex CLI
     missing/logged-out, `codex exec` errored or timed out, unsupported platform,
-    or OpenRouter returned no image after a retry). cmd_generate catches this and
-    falls back to another configured backend; it is NOT a hard caller error
-    (those stay `sys.exit`)."""
+    or OpenRouter returned no image after a retry). cmd_generate catches this so
+    it can fail cleanly or use an explicitly authorized fallback; it is NOT a
+    hard caller error (those stay `sys.exit`)."""
 
 
 def redact(text):
@@ -199,8 +200,9 @@ def grok_available():
     credential present (auth.json exists). Login is detected by the credential
     file's *existence* — never its contents (scanner-clean: no secret read, no
     secret-shaped env var). The image tools' reachability can't be probed without
-    a billed call, so a logged-out or image-ineligible account soft-fails at
-    generate time (→ BackendUnavailable → fallback), never here. Cached."""
+    a billed call, so a logged-out or image-ineligible account fails cleanly at
+    generate time (and only uses paid fallback when explicitly allowed), never
+    here. Cached."""
     global _GROK_AVAILABLE
     if _GROK_AVAILABLE is not None:
         return _GROK_AVAILABLE
@@ -939,9 +941,9 @@ def openrouter_generate(model, content, key, image_config=None):
 
 
 def _freshest_generated_image(since):
-    """Newest file under $CODEX_HOME/generated_images/ that postdates `since`
-    (a wall-clock float captured just before this exec ran), or None. The
-    recency floor is mandatory: the dir is shared across renders and across
+    """Newest $CODEX_HOME/generated_images/<session-id>/<image> that postdates
+    `since` (a wall-clock float captured just before this exec ran), or None.
+    The recency floor is mandatory: the dir is shared across renders and across
     concurrent codex sessions, so without it the agent failing to produce a new
     image (a non-deterministic miss) would silently return a leftover from
     a previous render or a foreign session — a duplicate in a --count batch, or
@@ -955,11 +957,32 @@ def _freshest_generated_image(since):
     if not gen.is_dir():
         return None
     floor = since - CODEX_MTIME_SKEW
-    recent = [(f.stat().st_mtime, f) for f in gen.iterdir() if f.is_file()]
-    recent = [(m, f) for m, f in recent if m >= floor]
+    # Codex 0.144.3 writes generated_images/<session-id>/<image>.png. Match that
+    # documented fixed depth rather than recursively walking unbounded history.
+    recent = []
+    for f in gen.glob("*/*"):
+        try:
+            mtime = f.stat().st_mtime
+        except OSError:
+            continue
+        if mtime >= floor and _valid_image_file(f):
+            recent.append((mtime, f))
     if not recent:
         return None
     return max(recent, key=lambda mf: mf[0])[1]
+
+
+def _valid_image_file(path):
+    """True for a parseable non-empty PNG/JPEG, false for missing/partial files."""
+    try:
+        p = pathlib.Path(path)
+        if not p.is_file() or p.stat().st_size == 0:
+            return False
+        data = p.read_bytes()
+        width, height = image_size(data)
+        return sniff_ext(data) is not None and bool(width and height)
+    except OSError:
+        return False
 
 
 def codex_exec_generate(prompt, refs, out_path):
@@ -967,9 +990,10 @@ def codex_exec_generate(prompt, refs, out_path):
     its built-in image_generation tool (gpt-image-2, no API key, no per-image
     charge). Returns (produced_file_path, partial_record). Sends NO model id —
     gpt-image-2 is automatic on the free built-in tool, so --model never
-    applies here. Every failure (CLI unusable, exec non-zero, timeout, no image)
-    raises BackendUnavailable for fallback. illo handles no token; the only
-    privileged action is this subprocess to the user's own CLI."""
+    applies here. A valid fresh artifact is authoritative even when the wrapper
+    exits non-zero or times out; only a run with no valid artifact raises
+    BackendUnavailable. illo handles no token; the only privileged action is
+    this subprocess to the user's own CLI."""
     if not codex_available():
         raise BackendUnavailable("Codex CLI not usable (not installed, logged out, "
                                  "or image_generation unavailable).")
@@ -1003,29 +1027,37 @@ def codex_exec_generate(prompt, refs, out_path):
     # postdate this moment, so a stale prior render or a concurrent session's
     # file in the shared generated_images dir can't pass as our result.
     started = time.time()
+
+    def produced_image():
+        """Return this run's requested/fallback artifact when it is a real image."""
+        if _valid_image_file(out):
+            return out
+        return _freshest_generated_image(started)
+
     try:
         proc = subprocess.run(cmd, input=stdin_prompt, capture_output=True,
                               text=True, timeout=CODEX_EXEC_TIMEOUT)
     except subprocess.TimeoutExpired:
+        produced = produced_image()
+        if produced is not None:
+            return produced, {"model": None, "id": None}
         raise BackendUnavailable("codex exec timed out before producing an image.")
     except (FileNotFoundError, OSError, subprocess.SubprocessError) as e:
         # Includes the unsupported-platform case (Windows/WSL exec breakage).
         raise BackendUnavailable(f"codex exec could not run: {e}")
+    # Artifact-first: Codex can persist image_generation output, then emit an
+    # empty final assistant response and exit 1. The image tool result is the
+    # render contract; wrapper text status must not discard it or trigger a
+    # second paid render.
+    produced = produced_image()
+    if produced is not None:
+        return produced, {"model": None, "id": None}
     if proc.returncode != 0:
         # Redact before this string can reach a terminal — never echo raw output.
         combined = redact((proc.stdout or "") + (proc.stderr or ""))
         raise BackendUnavailable(
             f"codex exec exited {proc.returncode}: {combined[:300]}")
-    # Verify-first (the agent's save-to-path works under workspace-write), then
-    # fall back to fetching the freshest file the built-in tool dropped under
-    # $CODEX_HOME/generated_images/.
-    if out.is_file() and out.stat().st_size > 0:
-        produced = out
-    else:
-        produced = _freshest_generated_image(started)
-        if produced is None:
-            raise BackendUnavailable("codex exec produced no retrievable image.")
-    return produced, {"model": None, "id": None}
+    raise BackendUnavailable("codex exec produced no retrievable image.")
 
 
 def _freshest_grok_image(since):
@@ -1059,8 +1091,9 @@ def grok_exec_generate(prompt, refs, out_path):
     no API key). Returns (produced_file_path, partial_record). Sends NO model id —
     the image tool is not the chat model, so --model never applies here. Every
     failure (CLI unusable, exit non-zero, timeout, no image) raises
-    BackendUnavailable for fallback. illo handles no token; the only privileged
-    action is this subprocess to the user's own CLI."""
+    BackendUnavailable so the caller can fail cleanly or use an explicitly
+    authorized fallback. illo handles no token; the only privileged action is
+    this subprocess to the user's own CLI."""
     if not grok_available():
         raise BackendUnavailable("Grok CLI not usable (not installed or logged out).")
     out = pathlib.Path(out_path).resolve()
@@ -1182,7 +1215,8 @@ def cmd_generate(args):
     for p in paths:
         rec = _render_one(backend, cfg, prompt, model, args.ref, args.cost, p,
                           cutout=args.cutout, image_config=image_config,
-                          chroma_key=chroma_key)
+                          chroma_key=chroma_key,
+                          allow_paid_fallback=args.allow_paid_fallback)
         rec["label"] = args.label or ""
         rec["prompt"] = prompt
         with manifest.open("a") as f:
@@ -1201,13 +1235,13 @@ def _apply_cutout_meta(rec, cutout_meta):
 
 
 def _render_one(backend, cfg, prompt, model, refs, want_cost, out_path,
-                cutout=False, image_config=None, chroma_key=CHROMA_MAGENTA):
+                cutout=False, image_config=None, chroma_key=CHROMA_MAGENTA,
+                allow_paid_fallback=False):
     """Render one image through the resolved backend and place it, returning the
-    manifest record. A subscription-CLI backend (Codex/Grok) failure raises
-    BackendUnavailable and falls back to a configured OpenRouter key (record tagged
-    backend=openrouter); a CLI-only host with no key exits with the fixes named.
-    The single file placement, sniff_ext, and the additive `backend` field live
-    here, never in a backend."""
+    manifest record. A subscription-CLI backend (Codex/Grok) failure only falls
+    back to a configured OpenRouter key when the caller explicitly permits the
+    paid fallback; otherwise it fails closed. The single file placement,
+    sniff_ext, and additive `backend` field live here, never in a backend."""
     # Resolve references once (with the default-character fallback) so every path
     # attaches the same sheet — CLI, direct OpenRouter, and the CLI→OpenRouter
     # fallback/redirect alike. Resolving only inside the CLI branch let a ref-less
@@ -1219,16 +1253,23 @@ def _render_one(backend, cfg, prompt, model, refs, want_cost, out_path,
         try:
             produced, meta = gen(prompt, refs, out_path)
         except BackendUnavailable as e:
-            if cfg.get("apiKey"):
+            if allow_paid_fallback and cfg.get("apiKey"):
                 sys.stderr.write(f"note: {backend} backend unavailable ({e}); "
                                  f"falling back to OpenRouter.\n")
                 return _openrouter_record(cfg, prompt, model, refs, want_cost, out_path,
                                           cutout=cutout, image_config=image_config,
                                           chroma_key=chroma_key)
+            if cfg.get("apiKey"):
+                sys.exit(f"{backend} backend failed: {e}\n"
+                         "Paid OpenRouter fallback is disabled. Retry with "
+                         "`--allow-paid-fallback` to permit a per-image charge, "
+                         f"or fix the {backend} backend.")
             login = "codex login" if backend == "codex" else "grok login"
             sys.exit(f"{backend} backend failed and no OpenRouter key is set: {e}\n"
                      f"Fix: ensure the CLI is installed + `{login}`, or run "
-                     f"`{PROG} init` to set an OpenRouter key.")
+                     f"`{PROG} init` to set a key and then choose direct "
+                     "`--backend openrouter` or retry with "
+                     "`--allow-paid-fallback`.")
         img = produced.read_bytes()
         path, w, h, cutout_meta = place_image(img, out_path, cutout=cutout,
                                               chroma_key=chroma_key)
@@ -1773,6 +1814,9 @@ def main():
     g.add_argument("--backend", choices=BACKENDS,
                    help="image backend (overrides config/default): codex or grok (your "
                         "subscription CLI) or openrouter; default resolves by host capability")
+    g.add_argument("--allow-paid-fallback", action="store_true",
+                   help="if a Codex/Grok subscription render fails, explicitly allow "
+                        "fallback to the configured paid OpenRouter API (off by default)")
     g.add_argument("--ref", action="append", default=[], help="reference image path (repeatable)")
     g.add_argument("--aspect", help="aspect ratio hint, e.g. 16:9")
     g.add_argument("--image-config",

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -1,8 +1,10 @@
 import importlib.util
+import os
 import tempfile
 import unittest
 from pathlib import Path
 from typing import Any, cast
+from unittest import mock
 
 
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "skills" / "illo" / "scripts" / "illo.py"
@@ -24,6 +26,21 @@ class FakeCompletedProcess:
         self.stderr = stderr
 
 
+def write_png_artifact(path):
+    """Write enough PNG structure for illo's artifact validation tests."""
+    path.write_bytes(
+        b"\x89PNG\r\n\x1a\n"
+        b"\x00\x00\x00\x0dIHDR"
+        b"\x00\x00\x00\x01\x00\x00\x00\x01"
+    )
+
+
+def generated_session(codex_home, generated_subdir):
+    session = Path(codex_home) / generated_subdir / "session-id"
+    session.mkdir(parents=True)
+    return session
+
+
 class CodexBackendTests(unittest.TestCase):
     def setUp(self):
         self.illo = load_illo_module()
@@ -42,7 +59,7 @@ class CodexBackendTests(unittest.TestCase):
             captured["capture_output"] = capture_output
             captured["text"] = text
             captured["timeout"] = timeout
-            out_path.write_bytes(b"not a real png, just a non-empty artifact")
+            write_png_artifact(out_path)
             return FakeCompletedProcess(returncode=0)
 
         with tempfile.TemporaryDirectory() as td:
@@ -73,6 +90,59 @@ class CodexBackendTests(unittest.TestCase):
         self.assertTrue(captured["capture_output"])
         self.assertTrue(captured["text"])
         self.assertEqual(captured["timeout"], self.illo.CODEX_EXEC_TIMEOUT)
+
+    def test_nonzero_exit_with_requested_output_succeeds(self):
+        def fake_run(cmd, input, capture_output, text, timeout):
+            write_png_artifact(out_path)
+            return FakeCompletedProcess(returncode=1, stderr="empty final response")
+
+        with tempfile.TemporaryDirectory() as td:
+            out_path = Path(td) / "requested.png"
+            self.illo.subprocess.run = fake_run
+            produced, meta = self.illo.codex_exec_generate(
+                "draw the mascot", [], out_path
+            )
+
+        self.assertEqual(produced, out_path.resolve())
+        self.assertEqual(meta, {"model": None, "id": None})
+
+    def test_nonzero_exit_with_fresh_nested_generated_artifact_succeeds(self):
+        with tempfile.TemporaryDirectory() as codex_home, tempfile.TemporaryDirectory() as td:
+            artifact = generated_session(
+                codex_home, self.illo.CODEX_GENERATED_SUBDIR
+            ) / "render.png"
+
+            def fake_run(cmd, input, capture_output, text, timeout):
+                write_png_artifact(artifact)
+                return FakeCompletedProcess(returncode=1, stderr="empty final response")
+
+            self.illo.subprocess.run = fake_run
+            with mock.patch.dict(os.environ, {"CODEX_HOME": codex_home}):
+                produced, meta = self.illo.codex_exec_generate(
+                    "draw the mascot", [], Path(td) / "requested.png"
+                )
+
+        self.assertEqual(produced, artifact)
+        self.assertEqual(meta, {"model": None, "id": None})
+
+    def test_timeout_with_fresh_nested_generated_artifact_succeeds(self):
+        with tempfile.TemporaryDirectory() as codex_home, tempfile.TemporaryDirectory() as td:
+            artifact = generated_session(
+                codex_home, self.illo.CODEX_GENERATED_SUBDIR
+            ) / "render.png"
+
+            def fake_run(cmd, input, capture_output, text, timeout):
+                write_png_artifact(artifact)
+                raise self.illo.subprocess.TimeoutExpired(cmd, timeout)
+
+            self.illo.subprocess.run = fake_run
+            with mock.patch.dict(os.environ, {"CODEX_HOME": codex_home}):
+                produced, meta = self.illo.codex_exec_generate(
+                    "draw the mascot", [], Path(td) / "requested.png"
+                )
+
+        self.assertEqual(produced, artifact)
+        self.assertEqual(meta, {"model": None, "id": None})
 
     def test_detect_codex_accepts_image_generation_alone(self):
         self.illo.shutil.which = lambda name: "/usr/local/bin/codex" if name == "codex" else None
@@ -120,6 +190,101 @@ class CodexBackendTests(unittest.TestCase):
         self.assertIn("<redacted>", msg)
         self.assertNotIn(fake_secret, msg)
         self.assertIn("stderr details", msg)
+
+    def test_nonzero_exit_with_invalid_fresh_nested_artifact_fails(self):
+        with tempfile.TemporaryDirectory() as codex_home, tempfile.TemporaryDirectory() as td:
+            artifact = generated_session(
+                codex_home, self.illo.CODEX_GENERATED_SUBDIR
+            ) / "partial.png"
+
+            def fake_run(cmd, input, capture_output, text, timeout):
+                artifact.write_bytes(b"not an image")
+                return FakeCompletedProcess(returncode=1, stderr="empty final response")
+
+            self.illo.subprocess.run = fake_run
+            with mock.patch.dict(os.environ, {"CODEX_HOME": codex_home}):
+                with self.assertRaises(self.illo.BackendUnavailable):
+                    self.illo.codex_exec_generate(
+                        "draw the mascot", [], Path(td) / "requested.png"
+                    )
+
+    def test_nonzero_exit_with_stale_nested_artifact_fails(self):
+        with tempfile.TemporaryDirectory() as codex_home, tempfile.TemporaryDirectory() as td:
+            artifact = generated_session(
+                codex_home, self.illo.CODEX_GENERATED_SUBDIR
+            ) / "stale.png"
+
+            def fake_run(cmd, input, capture_output, text, timeout):
+                write_png_artifact(artifact)
+                os.utime(artifact, (0, 0))
+                return FakeCompletedProcess(returncode=1, stderr="empty final response")
+
+            self.illo.subprocess.run = fake_run
+            with mock.patch.dict(os.environ, {"CODEX_HOME": codex_home}):
+                with self.assertRaises(self.illo.BackendUnavailable) as ctx:
+                    self.illo.codex_exec_generate(
+                        "draw the mascot", [], Path(td) / "requested.png"
+                    )
+
+        self.assertIn("codex exec exited 1", str(ctx.exception))
+
+    def test_nonzero_exit_with_no_artifact_fails(self):
+        def fake_run(cmd, input, capture_output, text, timeout):
+            return FakeCompletedProcess(returncode=1, stderr="empty final response")
+
+        with tempfile.TemporaryDirectory() as codex_home, tempfile.TemporaryDirectory() as td:
+            self.illo.subprocess.run = fake_run
+            with mock.patch.dict(os.environ, {"CODEX_HOME": codex_home}):
+                with self.assertRaises(self.illo.BackendUnavailable) as ctx:
+                    self.illo.codex_exec_generate(
+                        "draw the mascot", [], Path(td) / "requested.png"
+                    )
+
+        self.assertIn("codex exec exited 1", str(ctx.exception))
+
+
+class PaidFallbackTests(unittest.TestCase):
+    def setUp(self):
+        self.illo = load_illo_module()
+
+        def fail_codex(*args, **kwargs):
+            raise self.illo.BackendUnavailable("wrapper failed")
+
+        self.illo.codex_exec_generate = fail_codex
+
+    def test_default_cli_failure_never_calls_openrouter_with_configured_key(self):
+        def unexpected_openrouter(*args, **kwargs):
+            self.fail("OpenRouter must not be called without explicit paid fallback")
+
+        self.illo._openrouter_record = unexpected_openrouter
+        with tempfile.TemporaryDirectory() as td:
+            with self.assertRaises(SystemExit) as ctx:
+                self.illo._render_one(
+                    "codex", {"apiKey": "configured"}, "prompt", "model",
+                    ["ref.png"], False, Path(td) / "out.png"
+                )
+
+        self.assertIn("--allow-paid-fallback", str(ctx.exception))
+
+    def test_explicit_paid_fallback_records_openrouter_backend(self):
+        self.illo._openrouter_record = lambda *args, **kwargs: {"backend": "openrouter"}
+        with tempfile.TemporaryDirectory() as td:
+            rec = self.illo._render_one(
+                "codex", {"apiKey": "configured"}, "prompt", "model",
+                ["ref.png"], False, Path(td) / "out.png", allow_paid_fallback=True
+            )
+
+        self.assertEqual(rec["backend"], "openrouter")
+
+    def test_direct_openrouter_does_not_require_paid_fallback_flag(self):
+        self.illo._openrouter_record = lambda *args, **kwargs: {"backend": "openrouter"}
+        with tempfile.TemporaryDirectory() as td:
+            rec = self.illo._render_one(
+                "openrouter", {"apiKey": "configured"}, "prompt", "model",
+                ["ref.png"], False, Path(td) / "out.png"
+            )
+
+        self.assertEqual(rec["backend"], "openrouter")
 
 
 if __name__ == "__main__":

--- a/tests/test_grok_backend.py
+++ b/tests/test_grok_backend.py
@@ -211,7 +211,10 @@ class RenderRefResolutionTests(unittest.TestCase):
                 lambda cfg, prompt, model, refs, *a, **k: captured.update(refs=refs) or {}
             )
             cfg = {"apiKey": "k", "defaultCharacter": "bot"}
-            self.illo._render_one("grok", cfg, "p", "m", [], False, Path(cfgdir) / "o.png")
+            self.illo._render_one(
+                "grok", cfg, "p", "m", [], False, Path(cfgdir) / "o.png",
+                allow_paid_fallback=True,
+            )
             self.assertEqual(captured["refs"], [str(char_ref)])
 
 


### PR DESCRIPTION
## Summary

- Treat a valid requested output or fresh `$CODEX_HOME/generated_images/<session-id>/<image>.png` artifact as the authoritative Codex result, even when `codex exec` exits nonzero or times out after image generation completes.
- Make Codex/Grok → OpenRouter fallback fail closed by default. The new `--allow-paid-fallback` flag explicitly authorizes a pay-per-image retry; direct `--backend openrouter` and the intentional Grok cutout redirect keep working without it.
- Add regression coverage for the Codex 0.144.3 nested artifact shape, stale/invalid artifacts, timeout recovery, default no-spend behavior, explicit paid fallback, and direct OpenRouter routing.
- Tighten pack-driven visual QA: prohibited face-interior marks require a literal tight-crop inspection and are hard failures; facial/route strokes that fuse into anatomy also fail topology review.
- Update the root README, shipped README, `SKILL.md`, backend reference, and CLI help consistently.

## Why

Codex can finish `image_generation` and persist a PNG, then emit an empty final assistant response and exit 1. Checking the process status before the artifact discarded a successful subscription render and could silently trigger a second, paid OpenRouter render when a key was configured.

The image artifact is the render contract. Paid fallback now requires explicit per-invocation consent.

## Validation

- `python3 -m unittest discover -s tests -v` — 21 passed
- `python3 -m py_compile skills/illo/scripts/illo.py tests/test_codex_backend.py tests/test_grok_backend.py` — passed
- `python3 .github/scripts/skill_frontmatter_version.py skills/illo` — `0.31.2`
- `python3 .github/scripts/sync_plugin_versions.py --check` — all manifests at `0.31.2`
- `python3 skills/illo/scripts/illo.py generate --help` — includes `--allow-paid-fallback`
- `python3 skills/illo/scripts/illo.py doctor` — exit 0
- Hermes community-skill scanner — SAFE / allowed (only the existing sanctioned subprocess findings)
- `git diff --check` — passed

## Risk

No live image call is included in this PR validation. The regression tests exercise the observed nested Codex artifact shape with fresh, stale, and invalid artifacts, plus nonzero exits, timeout exceptions, and fallback dispatch. The cache fallback retains the existing mtime-based freshness heuristic, so truly simultaneous Codex renders sharing one `CODEX_HOME` can still race; the requested output path remains authoritative when present. Release/version fields are intentionally unchanged; Release Please owns the next version bump.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Core generate path changes when subscription renders succeed and when OpenRouter is charged; behavior is well covered by tests but affects billing and success semantics users rely on.
> 
> **Overview**
> **Codex rendering** now treats a valid requested output or fresh `$CODEX_HOME/generated_images/<session-id>/<image>.png` as success **before** trusting `codex exec` exit status—covering nonzero exits and timeouts after the image tool finishes. Artifact lookup uses the nested Codex 0.144 layout and `_valid_image_file` so stale or junk files do not count.
> 
> **Paid fallback** is opt-in: failed Codex/Grok renders **fail closed** when an OpenRouter key exists unless `generate` is passed **`--allow-paid-fallback`**. Direct `--backend openrouter` and intentional Grok cutout redirects are unchanged.
> 
> Docs (root README, skill README, `SKILL.md`, `references/backends.md`, CLI help) describe artifact-first behavior and the new flag. **`references/quality-bar.md`** adds hard-fail rules for prohibited face-interior marks (tight crop) and fused facial/route strokes; mini-comics run four structural checks per panel.
> 
> Regression tests cover nested artifacts, invalid/stale files, timeout recovery, default no-spend behavior, explicit fallback, and direct OpenRouter routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30b05ea0ae23554112f8ee7febbac1872776bb34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->