### PR TITLE
fix(illo): exclude prior count-batch artifacts from freshness fallback

### DIFF
--- a/skills/illo/scripts/illo.py
+++ b/skills/illo/scripts/illo.py
@@ -940,7 +940,7 @@ def openrouter_generate(model, content, key, image_config=None):
     return img, {"model": model, "id": gid}
 
 
-def _freshest_generated_image(since):
+def _freshest_generated_image(since, exclude=None):
     """Newest $CODEX_HOME/generated_images/<session-id>/<image> that postdates
     `since` (a wall-clock float captured just before this exec ran), or None.
     The recency floor is mandatory: the dir is shared across renders and across
@@ -951,16 +951,24 @@ def _freshest_generated_image(since):
     tolerates mtime granularity / clock skew. Resolves CODEX_HOME (env, default
     ~/.codex) at run time and NEVER hardcodes ~/.codex — the spike found Orca
     relocates it. CODEX_HOME is a path, not secret-shaped, so reading it
-    is allowed."""
+    is allowed.
+
+    `exclude` is a set of pathlib.Path instances that were known to exist in
+    the generated_images dir before this exec started. They are excluded from
+    the freshness search so that a serial --count batch cannot reuse a prior
+    iteration's artifact through the post-exec fallback."""
     home = os.environ.get("CODEX_HOME") or os.path.expanduser("~/.codex")
     gen = pathlib.Path(home) / CODEX_GENERATED_SUBDIR
     if not gen.is_dir():
         return None
     floor = since - CODEX_MTIME_SKEW
+    exclude = exclude or set()
     # Codex 0.144.3 writes generated_images/<session-id>/<image>.png. Match that
     # documented fixed depth rather than recursively walking unbounded history.
     recent = []
     for f in gen.glob("*/*"):
+        if f in exclude:
+            continue
         try:
             mtime = f.stat().st_mtime
         except OSError:
@@ -1027,12 +1035,20 @@ def codex_exec_generate(prompt, refs, out_path):
     # postdate this moment, so a stale prior render or a concurrent session's
     # file in the shared generated_images dir can't pass as our result.
     started = time.time()
+    # Snapshot pre-existing generated images so a serial --count batch cannot
+    # reuse a prior iteration's artifact through the post-exec fallback. The
+    # exclusion set shadows the same generated_images dir _freshest_generated_image
+    # will traverse, sharing the same CODEX_HOME resolution.
+    _codex_gen = pathlib.Path(
+        os.environ.get("CODEX_HOME") or os.path.expanduser("~/.codex")
+    ) / CODEX_GENERATED_SUBDIR
+    pre_existing = set(_codex_gen.glob("*/*")) if _codex_gen.is_dir() else set()
 
     def produced_image():
         """Return this run's requested/fallback artifact when it is a real image."""
         if _valid_image_file(out):
             return out
-        return _freshest_generated_image(started)
+        return _freshest_generated_image(started, exclude=pre_existing)
 
     try:
         proc = subprocess.run(cmd, input=stdin_prompt, capture_output=True,

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -242,6 +242,65 @@ class CodexBackendTests(unittest.TestCase):
 
         self.assertIn("codex exec exited 1", str(ctx.exception))
 
+    def test_count_batch_prior_artifact_not_reused(self):
+        """A prior --count iteration's artifact in generated_images must not
+        be silently returned when the current Codex exec fails to produce any
+        new artifact. Without the pre-exec snapshot exclusion, the prior
+        artifact's fresh mtime (within CODEX_MTIME_SKEW of start) would let
+        it pass the freshness floor. With exclusion it must be blocked."""
+        def fake_run(cmd, input, capture_output, text, timeout):
+            return FakeCompletedProcess(returncode=1, stderr="empty final response")
+
+        with tempfile.TemporaryDirectory() as codex_home, tempfile.TemporaryDirectory() as td:
+            # Simulate a prior iteration's nested artifact in generated_images.
+            # Its mtime will be recent enough to pass the freshness floor, so
+            # only the pre-exec snapshot exclusion prevents its reuse.
+            prior = generated_session(
+                codex_home, self.illo.CODEX_GENERATED_SUBDIR
+            ) / "previous-iteration.png"
+            write_png_artifact(prior)
+
+            self.illo.subprocess.run = fake_run
+            with mock.patch.dict(os.environ, {"CODEX_HOME": codex_home}):
+                with self.assertRaises(self.illo.BackendUnavailable) as ctx:
+                    self.illo.codex_exec_generate(
+                        "draw the mascot", [], Path(td) / "requested.png"
+                    )
+
+        self.assertIn("codex exec exited 1", str(ctx.exception))
+
+    def test_count_batch_fresh_artifact_still_detected_alongside_prior(self):
+        """When Codex creates a genuinely new nested artifact alongside a prior
+        iteration's artifact, the exclusion of pre-existing files must not
+        accidentally exclude the new one."""
+        with tempfile.TemporaryDirectory() as codex_home, tempfile.TemporaryDirectory() as td:
+            # Prior iteration's artifact — recent mtime, same layout.
+            prior = generated_session(
+                codex_home, self.illo.CODEX_GENERATED_SUBDIR
+            ) / "previous-iteration.png"
+            write_png_artifact(prior)
+
+            # Fresh artifact produced by THIS exec — different session dir so
+            # it's a different path from the excluded prior.
+            fresh_session = (
+                Path(codex_home) / self.illo.CODEX_GENERATED_SUBDIR / "other-session"
+            )
+            fresh_session.mkdir(parents=True)
+            fresh = fresh_session / "fresh-this-run.png"
+
+            def fake_run(cmd, input, capture_output, text, timeout):
+                write_png_artifact(fresh)
+                return FakeCompletedProcess(returncode=1, stderr="empty final response")
+
+            self.illo.subprocess.run = fake_run
+            with mock.patch.dict(os.environ, {"CODEX_HOME": codex_home}):
+                produced, meta = self.illo.codex_exec_generate(
+                    "draw the mascot", [], Path(td) / "requested.png"
+                )
+
+        self.assertEqual(produced, fresh)
+        self.assertEqual(meta, {"model": None, "id": None})
+
 
 class PaidFallbackTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary

Prevents a serial `--count` batch from silently reusing a prior iteration's `generated_images` artifact when the current Codex exec exits nonzero or times out without producing a new image.

**Problem:** `_freshest_generated_image` uses an mtime-based freshness floor (`started - CODEX_MTIME_SKEW`, 2s slack). In a tight serial `--count` batch, the prior iteration's nested artifact has an mtime within the skew window, so a failed exec can silently pick it up instead of raising `BackendUnavailable`.

**Fix:** Snapshot `generated_images/*/*` paths before each `codex_exec_generate` call and pass them as an exclusion set to `_freshest_generated_image`. A genuinely new artifact created by the current exec (different path, not in the snapshot) is unaffected.

## Validation

- `python3 -m unittest discover -s tests -v` — **23 passed** (2 new tests)
- `python3 -m py_compile` — passed
- `python3 .github/scripts/skill_frontmatter_version.py skills/illo` — `0.31.3`
- `python3 .github/scripts/sync_plugin_versions.py --check` — all manifests at `0.31.3`
- `python3 skills/illo/scripts/illo.py doctor` — exit 0; assets OK; Codex usable
- `python3 skills/illo/scripts/illo.py generate --help` — includes `--allow-paid-fallback`
- `git diff --check` — passed

## Risk

No live image call. The exclusion set is a paths-only snapshot — no content reading, no mtime comparison. The residual risk from truly simultaneous renders sharing one `CODEX_HOME` persists (the mtime floor is still the guard there); the `--out` verify-first path remains authoritative when present.

## Follow-up

This addresses the late review comment at https://github.com/tmchow/illo-skill/pull/40#discussion_r357595102 (Cursor Bugbot, High Severity). PR #40 was merged and released as `v0.31.3` before the comment arrived.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to Codex artifact discovery after failed exec; path-only snapshot with tests. Concurrent sessions sharing one CODEX_HOME still rely on the existing mtime floor.
> 
> **Overview**
> Fixes **silent duplicate/wrong-image success** in serial `--count` Codex runs when `codex exec` fails or times out without writing `--out`.
> 
> **`_freshest_generated_image`** now takes an optional **`exclude`** set of paths already present under `CODEX_HOME/generated_images/*/*`. Those files are skipped when picking the newest mtime-qualified artifact, so a prior iteration’s PNG cannot satisfy the post-exec fallback just because its mtime is still inside **`CODEX_MTIME_SKEW`**.
> 
> **`codex_exec_generate`** snapshots that path set immediately before each exec (same `CODEX_HOME` resolution as the finder) and passes it into the fallback. New images created during the current run remain eligible because they were not in the snapshot.
> 
> Adds two unit tests: failed exec with only a prior artifact must raise **`BackendUnavailable`**; failed exec with a new nested artifact alongside a prior one must return the new file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acd39201602799f688e42424146a138fc83c93c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Post-merge follow-up

PR #42 merged with the snapshot-only fix before the thread-association review could be applied. Its behavior and residual concurrent-session risk remain exactly as described above. Draft PR #44 adds validated Codex JSONL thread association so the invocation-specific `generated_images/<thread-id>/` directory is preferred, while retaining this snapshot logic as the degraded compatibility fallback: https://github.com/tmchow/illo-skill/pull/44