### PR TITLE
fix(illo): scope Codex artifacts to exec thread

### DIFF
--- a/skills/illo/scripts/illo.py
+++ b/skills/illo/scripts/illo.py
@@ -940,7 +940,32 @@ def openrouter_generate(model, content, key, image_config=None):
     return img, {"model": model, "id": gid}
 
 
-def _freshest_generated_image(since, exclude=None):
+def _codex_thread_id(output):
+    """Return a safe thread id from `codex exec --json` JSONL, or None.
+
+    `subprocess.TimeoutExpired.stdout` can be bytes even when run() used
+    text=True, and can also be None when the process emitted nothing."""
+    if isinstance(output, bytes):
+        output = output.decode("utf-8", errors="replace")
+    if not isinstance(output, str):
+        return None
+    for line in output.splitlines():
+        try:
+            event = json.loads(line)
+        except (TypeError, json.JSONDecodeError):
+            continue
+        if not isinstance(event, dict) or event.get("type") != "thread.started":
+            continue
+        thread_id = event.get("thread_id")
+        if (not isinstance(thread_id, str) or not thread_id
+                or thread_id in (".", "..") or "/" in thread_id
+                or "\\" in thread_id or "\x00" in thread_id):
+            continue
+        return thread_id
+    return None
+
+
+def _freshest_generated_image(since, exclude=None, thread_id=None):
     """Newest $CODEX_HOME/generated_images/<session-id>/<image> that postdates
     `since` (a wall-clock float captured just before this exec ran), or None.
     The recency floor is mandatory: the dir is shared across renders and across
@@ -953,20 +978,23 @@ def _freshest_generated_image(since, exclude=None):
     relocates it. CODEX_HOME is a path, not secret-shaped, so reading it
     is allowed.
 
-    `exclude` is a set of pathlib.Path instances that were known to exist in
-    the generated_images dir before this exec started. They are excluded from
-    the freshness search so that a serial --count batch cannot reuse a prior
-    iteration's artifact through the post-exec fallback."""
+    When `thread_id` came from the exec's validated `thread.started` event,
+    only that exact session directory is searched. Otherwise `exclude` holds
+    the fixed-depth paths that existed before this exec, preserving recovery
+    for older/malformed output while preventing serial --count reuse."""
     home = os.environ.get("CODEX_HOME") or os.path.expanduser("~/.codex")
     gen = pathlib.Path(home) / CODEX_GENERATED_SUBDIR
     if not gen.is_dir():
         return None
     floor = since - CODEX_MTIME_SKEW
     exclude = exclude or set()
-    # Codex 0.144.3 writes generated_images/<session-id>/<image>.png. Match that
-    # documented fixed depth rather than recursively walking unbounded history.
+    # Codex 0.144.3 writes generated_images/<session-id>/<image>.png. Prefer the
+    # invocation's exact session dir when JSONL identified it; otherwise match
+    # the same fixed depth rather than recursively walking unbounded history.
+    candidates = ((gen / thread_id).glob("*") if thread_id is not None
+                  else gen.glob("*/*"))
     recent = []
-    for f in gen.glob("*/*"):
+    for f in candidates:
         if f in exclude:
             continue
         try:
@@ -1016,7 +1044,7 @@ def codex_exec_generate(prompt, refs, out_path):
                     f"Use your built-in image generation tool to render this, "
                     f"then save the resulting image to {out} "
                     f"(overwrite if it exists). Do not ask for confirmation.")
-    cmd = [_codex_binary(), "exec", "--cd", str(run_dir),
+    cmd = [_codex_binary(), "exec", "--json", "--cd", str(run_dir),
            "--sandbox", "workspace-write", "--skip-git-repo-check"]
     # Attach every reference: the active character sheet, plus any finished-look
     # style anchor illo passes for within-set consistency. codex exec -i
@@ -1044,17 +1072,19 @@ def codex_exec_generate(prompt, refs, out_path):
     ) / CODEX_GENERATED_SUBDIR
     pre_existing = set(_codex_gen.glob("*/*")) if _codex_gen.is_dir() else set()
 
-    def produced_image():
+    def produced_image(output=None):
         """Return this run's requested/fallback artifact when it is a real image."""
         if _valid_image_file(out):
             return out
-        return _freshest_generated_image(started, exclude=pre_existing)
+        thread_id = _codex_thread_id(output)
+        return _freshest_generated_image(
+            started, exclude=pre_existing, thread_id=thread_id)
 
     try:
         proc = subprocess.run(cmd, input=stdin_prompt, capture_output=True,
                               text=True, timeout=CODEX_EXEC_TIMEOUT)
-    except subprocess.TimeoutExpired:
-        produced = produced_image()
+    except subprocess.TimeoutExpired as e:
+        produced = produced_image(e.stdout)
         if produced is not None:
             return produced, {"model": None, "id": None}
         raise BackendUnavailable("codex exec timed out before producing an image.")
@@ -1065,7 +1095,7 @@ def codex_exec_generate(prompt, refs, out_path):
     # empty final assistant response and exit 1. The image tool result is the
     # render contract; wrapper text status must not discard it or trigger a
     # second paid render.
-    produced = produced_image()
+    produced = produced_image(proc.stdout)
     if produced is not None:
         return produced, {"model": None, "id": None}
     if proc.returncode != 0:

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -1,4 +1,5 @@
 import importlib.util
+import json
 import os
 import tempfile
 import unittest
@@ -41,6 +42,11 @@ def generated_session(codex_home, generated_subdir):
     return session
 
 
+def thread_started_json(thread_id, as_bytes=False):
+    output = json.dumps({"type": "thread.started", "thread_id": thread_id}) + "\n"
+    return output.encode() if as_bytes else output
+
+
 class CodexBackendTests(unittest.TestCase):
     def setUp(self):
         self.illo = load_illo_module()
@@ -81,6 +87,7 @@ class CodexBackendTests(unittest.TestCase):
         # image_generation); illo must no longer enable it.
         self.assertNotIn("--enable", cmd)
         self.assertNotIn("imagegenext", cmd)
+        self.assertIn("--json", cmd)
         self.assertEqual(cmd.count("-i"), 2)
         self.assertIn(str(refs[0]), cmd)
         self.assertIn(str(refs[1]), cmd)
@@ -142,6 +149,51 @@ class CodexBackendTests(unittest.TestCase):
                 )
 
         self.assertEqual(produced, artifact)
+        self.assertEqual(meta, {"model": None, "id": None})
+
+    def test_thread_id_parser_accepts_text_and_timeout_bytes(self):
+        thread_id = "019f5f08-255f-7032-abc2-e8f3451a2043"
+        for output in (thread_started_json(thread_id),
+                       thread_started_json(thread_id, as_bytes=True)):
+            with self.subTest(output_type=type(output).__name__):
+                self.assertEqual(self.illo._codex_thread_id(output), thread_id)
+        self.assertIsNone(self.illo._codex_thread_id(None))
+
+    def test_thread_id_parser_rejects_unsafe_path_components(self):
+        for thread_id in ("", ".", "..", "../foreign", "foreign/session",
+                          "foreign\\session", "foreign\x00session"):
+            with self.subTest(thread_id=repr(thread_id)):
+                self.assertIsNone(
+                    self.illo._codex_thread_id(thread_started_json(thread_id)))
+
+    def test_thread_event_prefers_own_artifact_over_newer_foreign_session(self):
+        with tempfile.TemporaryDirectory() as codex_home, tempfile.TemporaryDirectory() as td:
+            generated = Path(codex_home) / self.illo.CODEX_GENERATED_SUBDIR
+            own_session = generated / "own-session"
+            foreign_session = generated / "foreign-session"
+            own_session.mkdir(parents=True)
+            foreign_session.mkdir(parents=True)
+            own = own_session / "own.png"
+            foreign = foreign_session / "foreign.png"
+
+            def fake_run(cmd, input, capture_output, text, timeout):
+                write_png_artifact(own)
+                write_png_artifact(foreign)
+                own_mtime = own.stat().st_mtime
+                os.utime(foreign, (own_mtime + 1, own_mtime + 1))
+                return FakeCompletedProcess(
+                    returncode=1,
+                    stdout=cast(str, thread_started_json("own-session")),
+                    stderr="empty final response",
+                )
+
+            self.illo.subprocess.run = fake_run
+            with mock.patch.dict(os.environ, {"CODEX_HOME": codex_home}):
+                produced, meta = self.illo.codex_exec_generate(
+                    "draw the mascot", [], Path(td) / "requested.png"
+                )
+
+        self.assertEqual(produced, own)
         self.assertEqual(meta, {"model": None, "id": None})
 
     def test_detect_codex_accepts_image_generation_alone(self):
@@ -268,6 +320,30 @@ class CodexBackendTests(unittest.TestCase):
                     )
 
         self.assertIn("codex exec exited 1", str(ctx.exception))
+
+    def test_count_batch_prior_artifact_not_reused_after_timeout(self):
+        """Timeout recovery must not reuse the previous serial iteration,
+        including when TimeoutExpired carries partial JSONL as bytes."""
+        def fake_run(cmd, input, capture_output, text, timeout):
+            raise self.illo.subprocess.TimeoutExpired(
+                cmd, timeout,
+                output=thread_started_json("current-session", as_bytes=True),
+            )
+
+        with tempfile.TemporaryDirectory() as codex_home, tempfile.TemporaryDirectory() as td:
+            prior = generated_session(
+                codex_home, self.illo.CODEX_GENERATED_SUBDIR
+            ) / "previous-iteration.png"
+            write_png_artifact(prior)
+
+            self.illo.subprocess.run = fake_run
+            with mock.patch.dict(os.environ, {"CODEX_HOME": codex_home}):
+                with self.assertRaises(self.illo.BackendUnavailable) as ctx:
+                    self.illo.codex_exec_generate(
+                        "draw the mascot", [], Path(td) / "requested.png"
+                    )
+
+        self.assertIn("timed out before producing an image", str(ctx.exception))
 
     def test_count_batch_fresh_artifact_still_detected_alongside_prior(self):
         """When Codex creates a genuinely new nested artifact alongside a prior


### PR DESCRIPTION
## Summary

- Run `codex exec` with `--json` and parse its first `thread.started` JSONL event.
- Validate `thread_id` before using it as a path component, then prefer only `$CODEX_HOME/generated_images/<thread_id>/*` for artifact recovery.
- Preserve the requested `--out` file as authoritative and retain PR #42's pre-exec fixed-depth path snapshot as a compatibility fallback when stdout is absent, malformed, or from an older CLI.
- Preserve the existing mtime floor and valid-image checks in both the thread-bound and compatibility paths.

## Why

PR #42 fixed serial `--count` reuse by excluding paths that existed before an invocation. That still allowed a newer artifact from a different concurrent Codex session to win the global mtime search. Codex 0.144.3 exposes the invocation's thread ID, and its image-generation implementation uses the same ID as the generated-image directory name, so recovery can normally be scoped to the producing session.

## Codex 0.144.3 verification

- Installed CLI and npm package both report `0.144.3`.
- A live text-only `codex exec --json` smoke test emitted `{"type":"thread.started","thread_id":"019f5f08-255f-7032-abc2-e8f3451a2043"}` as its first stdout event.
- Exact upstream tag `rust-v0.144.3` resolves to commit `78ad6e6bfd1d3b6a209acd3ef82172a96b25179c`.
- In that source, `exec_events.rs` documents `thread.started` as the first JSONL event; `event_processor_with_jsonl_output.rs` emits `session_configured.thread_id`; and `stream_events_utils.rs` stores images under `generated_images/<session_id>/<call_id>.png`.
- Python's `TimeoutExpired.stdout` was verified as `bytes` with partial output even when `subprocess.run(..., text=True)` was used, and as `None` when no output was captured. The parser accepts `str`, `bytes`, or `None` accordingly.

## Validation

- `python3 -m unittest discover -s tests -v` — **27 passed**
- `python3 -m unittest tests.test_codex_backend -v` — **19 passed**
- `python3 -m py_compile skills/illo/scripts/illo.py tests/test_codex_backend.py tests/test_grok_backend.py` — passed
- `python3 .github/scripts/skill_frontmatter_version.py skills/illo` — `0.31.4`
- `python3 .github/scripts/sync_plugin_versions.py --check` — all manifests at `0.31.4`
- `python3 skills/illo/scripts/illo.py doctor` — exit 0; assets OK; Codex usable
- `python3 skills/illo/scripts/illo.py generate --help` — includes `--allow-paid-fallback`
- `git diff --check` — passed

New regression coverage includes nonzero and timeout serial-reuse failures, `str`/`bytes`/`None` JSONL handling, unsafe thread IDs, and a newer concurrent foreign-session artifact not beating the invocation's own artifact.

## Risk

No live image call was made. On Codex 0.144.3, a usable `thread.started` event removes cross-session ambiguity from nested artifact recovery. If no usable event is captured, recovery intentionally falls back to the PR #42 snapshot plus mtime/image-validation heuristic for compatibility; a genuinely new concurrent foreign-session artifact can still win only on that degraded fallback path. The requested output path remains authoritative when present.

## Relationship

Follow-up to merged PR #42, which was itself the follow-up to the late Cursor comment on PR #40: https://github.com/tmchow/illo-skill/pull/40#discussion_r3575951021

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only Codex artifact recovery logic; wrong thread parsing could miss images, but requested --out and the legacy exclude path limit blast radius.
> 
> **Overview**
> **Codex image recovery is tied to the exec session** so concurrent or foreign `generated_images` files no longer win over this invocation’s output.
> 
> `codex exec` now runs with **`--json`**. A new **`_codex_thread_id`** helper reads the first `thread.started` JSONL line from stdout (including **`bytes`** on timeout), rejects unsafe path components, and **`_freshest_generated_image`** searches only **`generated_images/<thread_id>/*`** when that ID is present. Without usable JSONL, behavior stays on the prior **pre-exec snapshot + `*/*` glob** path with the same mtime and image checks. **`produced_image`** passes **`proc.stdout`** or timeout partial output into that flow.
> 
> Tests assert **`--json` on the command**, parser edge cases, own-session vs newer foreign session, and timeout + partial JSONL not reusing a prior **`--count`** artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e05fcbced6d1dbd3c24f5d408162dceaadf4ceb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->