### PR TITLE
fix: enforce conventional PR titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,22 @@
+name: Conventional PR title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions: {}
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate Conventional Commit title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          pattern='^(feat|fix|perf|revert|docs|style|refactor|test|build|ci|chore)(\([a-z0-9._/-]+\))?!?:[[:space:]]+[^[:space:]].*$'
+          if [[ ! "$PR_TITLE" =~ $pattern ]]; then
+            echo "::error::PR title must use Conventional Commit format, for example: feat: add a new print look"
+            echo "Allowed types: feat, fix, perf, revert, docs, style, refactor, test, build, ci, chore."
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,15 @@ skill, six manifests, one version:
   directly, and the repo carries the `agent-skills` topic so
   `gh skill search` finds it.
 
+**Every PR title must use Conventional Commit format** because squash merges
+make the PR title the commit that Release Please reads. The
+`.github/workflows/pr-title.yml` check enforces this for all PRs, including
+forks. Allowed types are `feat`, `fix`, `perf`, `revert`, `docs`, `style`,
+`refactor`, `test`, `build`, `ci`, and `chore`. Use
+`feat: add a new print look` or `fix: correct rendering guidance` for
+installed skill changes; use `docs:`, `chore:`, or `ci:` as appropriate for
+repo-only changes that should not trigger a skill release.
+
 **Release Please is the release authority.** Ordinary feature/fix PRs should
 not edit version fields. On pushes to `main`,
 `.github/workflows/release-please.yml` maintains a release PR that bumps


### PR DESCRIPTION
## Summary

- add a dependency-free `pull_request` check that requires Conventional Commit PR titles
- run the check with no repository permissions, no checkout, and no secrets so fork PRs are safe
- document the required title format and release semantics for contributors

## Release context

`main` contains `skills/illo/references/styles/snes.md`, but the latest published release, v0.31.5, does not. PR #46 was squash-merged with a non-Conventional title, so successful Release Please run 30144642069 found no release-triggering commit and did not open a release PR.

This guard validates the title GitHub will use for squash merges, including title edits and fork PRs. This PR deliberately uses a release-triggering Conventional title so the next Release Please pass can publish the current contents of `main`, including the prior SNES style change.

## Tests

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7`
- `python3 -m unittest discover -s tests -v` (27 passed)
- `python3 .github/scripts/sync_plugin_versions.py --check`
- `python3 .github/scripts/regen_asset_checksums.py --check`
- `git diff --check`
- title regex matrix: 4 valid titles accepted and 4 invalid titles rejected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and contributor docs only; no runtime, auth, or skill install behavior changes.
> 
> **Overview**
> Adds a **pull_request** workflow that rejects PR titles that are not valid Conventional Commits, so squash-merge commits on `main` stay parseable by Release Please.
> 
> The job uses **empty permissions**, no checkout, and only `github.event.pull_request.title` with a bash regex over allowed types (`feat`, `fix`, `ci`, `chore`, etc.). **AGENTS.md** now states that PR titles are the release signal and points contributors at the check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc443ea78991f19c5d0bf698437b900946b3bf58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->