### PR TITLE
fix: validate release commit metadata

### DIFF
--- a/.github/scripts/validate_pr_commits.py
+++ b/.github/scripts/validate_pr_commits.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Validate commit subjects that Release Please can read from a pull request."""
+
+import argparse
+import re
+import subprocess
+import sys
+
+
+CONVENTIONAL_SUBJECT = re.compile(
+    r"^(feat|fix|perf|revert|docs|style|refactor|test|build|ci|chore)"
+    r"(\([a-z0-9._/-]+\))?!?:\s+\S.*$"
+)
+RELEASE_SUBJECT = re.compile(
+    r"^(feat|fix|perf|revert)(\([a-z0-9._/-]+\))?!?:\s+\S.*$"
+)
+INSTALLED_SKILL_PREFIX = "skills/illo/"
+
+
+def validate(commits, changed_paths):
+    """Return validation errors for (sha, subject, is_merge) commit tuples."""
+    errors = []
+    non_merge_commits = [commit for commit in commits if not commit[2]]
+
+    if not non_merge_commits:
+        errors.append("Pull request has no non-merge commits to validate.")
+        return errors
+
+    for sha, subject, _is_merge in non_merge_commits:
+        if not CONVENTIONAL_SUBJECT.fullmatch(subject):
+            errors.append(
+                f"Commit {sha[:12]} has a non-conventional subject: {subject!r}"
+            )
+
+    changes_installed_skill = any(
+        path == INSTALLED_SKILL_PREFIX.rstrip("/")
+        or path.startswith(INSTALLED_SKILL_PREFIX)
+        for path in changed_paths
+    )
+    if changes_installed_skill and not any(
+        RELEASE_SUBJECT.fullmatch(subject)
+        for _sha, subject, _is_merge in non_merge_commits
+    ):
+        errors.append(
+            "Changes under skills/illo/** require at least one non-merge "
+            "feat:, fix:, perf:, or revert: commit."
+        )
+
+    return errors
+
+
+def git(*args):
+    return subprocess.check_output(
+        ["git", *args], text=True, stderr=subprocess.STDOUT
+    ).strip()
+
+
+def load_pull_request(base_sha, head_sha):
+    merge_base = git("merge-base", base_sha, head_sha)
+    revision_range = f"{merge_base}..{head_sha}"
+    commits = []
+
+    for line in git("rev-list", "--reverse", "--parents", revision_range).splitlines():
+        fields = line.split()
+        sha = fields[0]
+        subject = git("show", "-s", "--format=%s", sha)
+        commits.append((sha, subject, len(fields) > 2))
+
+    changed_output = git("diff", "--name-only", revision_range)
+    changed_paths = changed_output.splitlines() if changed_output else []
+    return commits, changed_paths
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base", required=True, help="pull request base SHA")
+    parser.add_argument("--head", required=True, help="pull request head SHA")
+    args = parser.parse_args()
+
+    commits, changed_paths = load_pull_request(args.base, args.head)
+    errors = validate(commits, changed_paths)
+    if errors:
+        for error in errors:
+            print(f"::error::{error}")
+        print(
+            "Use Conventional Commit subjects such as "
+            "'fix: correct rendering guidance'."
+        )
+        return 1
+
+    print(f"Validated {len(commits)} pull request commit(s).")
+    if any(
+        path == INSTALLED_SKILL_PREFIX.rstrip("/")
+        or path.startswith(INSTALLED_SKILL_PREFIX)
+        for path in changed_paths
+    ):
+        print("Installed-skill change includes a release-triggering commit.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,4 +1,4 @@
-name: Conventional PR title
+name: Conventional PR metadata
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
 permissions: {}
 
 jobs:
-  validate:
+  title:
     runs-on: ubuntu-latest
     steps:
       - name: Validate Conventional Commit title
@@ -20,3 +20,19 @@ jobs:
             echo "Allowed types: feat, fix, perf, revert, docs, style, refactor, test, build, ci, chore."
             exit 1
           fi
+
+  commits:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out pull request history
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Validate Conventional Commit subjects
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: python3 .github/scripts/validate_pr_commits.py --base "$BASE_SHA" --head "$HEAD_SHA"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,14 +240,18 @@ skill, six manifests, one version:
   directly, and the repo carries the `agent-skills` topic so
   `gh skill search` finds it.
 
-**Every PR title must use Conventional Commit format** because squash merges
-make the PR title the commit that Release Please reads. The
-`.github/workflows/pr-title.yml` check enforces this for all PRs, including
-forks. Allowed types are `feat`, `fix`, `perf`, `revert`, `docs`, `style`,
-`refactor`, `test`, `build`, `ci`, and `chore`. Use
-`feat: add a new print look` or `fix: correct rendering guidance` for
-installed skill changes; use `docs:`, `chore:`, or `ci:` as appropriate for
-repo-only changes that should not trigger a skill release.
+**Every PR title and every non-merge PR commit subject must use Conventional
+Commit format.** PR-title validation preserves useful release metadata when a
+squash merge uses the PR title, but it does not protect merge-commit or rebase
+flows by itself. Under the repository's merge-commit settings, Release Please
+may skip the generated `Merge pull request ...` wrapper and inspect its child
+commits instead. The `.github/workflows/pr-title.yml` checks both surfaces for
+all PRs, including forks. Allowed types are `feat`, `fix`, `perf`, `revert`,
+`docs`, `style`, `refactor`, `test`, `build`, `ci`, and `chore`. If a PR changes
+anything under `skills/illo/**`, at least one non-merge commit must use
+`feat:`, `fix:`, `perf:`, or `revert:` so Release Please sees a release trigger.
+Use `docs:`, `chore:`, or `ci:` as appropriate for repo-only changes that
+should not trigger a skill release.
 
 **Release Please is the release authority.** Ordinary feature/fix PRs should
 not edit version fields. On pushes to `main`,

--- a/tests/test_validate_pr_commits.py
+++ b/tests/test_validate_pr_commits.py
@@ -1,0 +1,84 @@
+import importlib.util
+import unittest
+from pathlib import Path
+from typing import Any, cast
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / ".github"
+    / "scripts"
+    / "validate_pr_commits.py"
+)
+
+
+def load_validator_module():
+    spec = importlib.util.spec_from_file_location("validator_under_test", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load validator from {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return cast(Any, module)
+
+
+class PullRequestCommitValidationTests(unittest.TestCase):
+    def setUp(self):
+        self.validator = load_validator_module()
+
+    def commit(self, subject, merge=False):
+        return ("a" * 40, subject, merge)
+
+    def test_merge_strategy_validates_release_please_child_commits(self):
+        commits = [
+            self.commit("feat: add SNES look"),
+            self.commit("Merge pull request #46 from tmchow/add-snes-look", merge=True),
+        ]
+
+        self.assertEqual(
+            self.validator.validate(commits, ["skills/illo/references/styles/snes.md"]),
+            [],
+        )
+
+        errors = self.validator.validate(
+            [self.commit("Add SNES look")],
+            ["skills/illo/references/styles/snes.md"],
+        )
+        self.assertTrue(any("non-conventional" in error for error in errors))
+
+    def test_repo_only_ci_and_docs_commits_are_valid(self):
+        for subject in ("ci: tighten checks", "docs: clarify contribution rules"):
+            with self.subTest(subject=subject):
+                self.assertEqual(
+                    self.validator.validate(
+                        [self.commit(subject)], [".github/workflows/pr-title.yml"]
+                    ),
+                    [],
+                )
+
+    def test_installed_skill_fix_and_feat_commits_are_valid(self):
+        for subject in (
+            "fix: correct rendering guidance",
+            "feat(illo)!: replace the rendering contract",
+        ):
+            with self.subTest(subject=subject):
+                self.assertEqual(
+                    self.validator.validate(
+                        [self.commit(subject)], ["skills/illo/SKILL.md"]
+                    ),
+                    [],
+                )
+
+    def test_installed_skill_with_only_ci_or_docs_is_rejected(self):
+        commits = [
+            self.commit("ci: update checks"),
+            self.commit("docs: describe the change"),
+        ]
+
+        errors = self.validator.validate(commits, ["skills/illo/SKILL.md"])
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("require at least one", errors[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- keep Conventional Commit validation for PR titles so squash merges retain useful release metadata
- validate every non-merge PR commit subject, which is the metadata Release Please can fall through to under merge-commit and rebase flows
- require at least one `feat:`, `fix:`, `perf:`, or `revert:` child commit whenever `skills/illo/**` changes
- document the actual merge-strategy behavior and cover it with a regression matrix

## Why this follow-up

#47 only validated PR titles. That is useful for squash merges, but it did not protect the repository's allowed merge-commit path. With `merge_commit_title=MERGE_MESSAGE` and `merge_commit_message=PR_TITLE`, main received `Merge pull request ...` wrappers plus the original child commit subjects.

[Release Please run 30189277589](https://github.com/tmchow/illo-skill/actions/runs/30189277589) succeeded but opened no release PR. Its log could not parse the #46/#47 merge wrappers or the SNES child commit, then found #47's `ci:` child but correctly classified it as not user-facing. The SNES skill file therefore landed on main without advancing the release sequence.

This follow-up deliberately has one parseable child commit, `fix: validate release commit metadata`. Under the same merge strategy, Release Please can recognize that child as a patch trigger and create the next cumulative release PR, which will include the already-landed SNES file. The new check makes future installed-skill PRs without release-triggering child metadata fail CI while retaining title validation for squash mode.

## Verification

- `python3 -m unittest discover -s tests -v` — 31 tests passed
- `python3 .github/scripts/sync_plugin_versions.py --check` — all manifests at 0.31.5
- `python3 .github/scripts/regen_asset_checksums.py --check` — checksums.txt is current
- `python3 .github/scripts/validate_pr_commits.py --base 56b02d8 --head a2ccf5a` — rejected the observed non-conventional SNES child and missing release trigger as expected
- `python3 .github/scripts/validate_pr_commits.py --base origin/main --head HEAD` — validated this PR's single `fix:` commit
- `git diff --check origin/main...HEAD` — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and contributor-documentation only; no runtime skill or release workflow logic changes beyond stricter PR metadata checks.
> 
> **Overview**
> Extends **Conventional PR metadata** checks so Release Please can read valid commit subjects on merge-commit and rebase flows, not only when squash merges use the PR title.
> 
> Adds `.github/scripts/validate_pr_commits.py`, which walks non-merge commits between base and head, enforces conventional subjects on each, and when `skills/illo/**` changes requires at least one `feat:`, `fix:`, `perf:`, or `revert:` child commit. The workflow renames to **Conventional PR metadata**, keeps the existing title job, and adds a **commits** job that checks out full history and runs the script. **AGENTS.md** documents title vs. child-commit rules and the installed-skill release trigger. Unit tests in `tests/test_validate_pr_commits.py` cover merge wrappers, repo-only `ci:`/`docs:`, and skill-path release requirements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d78b0b4d67d7ac6fd1fbdecf328dfbdb54f8048. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->