### PR TITLE
ci: allow generated release metadata

### DIFF
--- a/.github/scripts/validate_pr_commits.py
+++ b/.github/scripts/validate_pr_commits.py
@@ -17,7 +17,7 @@ RELEASE_SUBJECT = re.compile(
 INSTALLED_SKILL_PREFIX = "skills/illo/"
 
 
-def validate(commits, changed_paths):
+def validate(commits, changed_paths, trusted_release_pr=False):
     """Return validation errors for (sha, subject, is_merge) commit tuples."""
     errors = []
     non_merge_commits = [commit for commit in commits if not commit[2]]
@@ -37,7 +37,7 @@ def validate(commits, changed_paths):
         or path.startswith(INSTALLED_SKILL_PREFIX)
         for path in changed_paths
     )
-    if changes_installed_skill and not any(
+    if changes_installed_skill and not trusted_release_pr and not any(
         RELEASE_SUBJECT.fullmatch(subject)
         for _sha, subject, _is_merge in non_merge_commits
     ):
@@ -75,10 +75,15 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--base", required=True, help="pull request base SHA")
     parser.add_argument("--head", required=True, help="pull request head SHA")
+    parser.add_argument(
+        "--trusted-release-pr",
+        action="store_true",
+        help="allow a trusted generated Release Please PR to change installed files",
+    )
     args = parser.parse_args()
 
     commits, changed_paths = load_pull_request(args.base, args.head)
-    errors = validate(commits, changed_paths)
+    errors = validate(commits, changed_paths, args.trusted_release_pr)
     if errors:
         for error in errors:
             print(f"::error::{error}")
@@ -94,7 +99,10 @@ def main():
         or path.startswith(INSTALLED_SKILL_PREFIX)
         for path in changed_paths
     ):
-        print("Installed-skill change includes a release-triggering commit.")
+        if args.trusted_release_pr:
+            print("Trusted generated release PR has conventional commit metadata.")
+        else:
+            print("Installed-skill change includes a release-triggering commit.")
     return 0
 
 

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -35,4 +35,10 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: python3 .github/scripts/validate_pr_commits.py --base "$BASE_SHA" --head "$HEAD_SHA"
+          TRUSTED_RELEASE_PR: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'github-actions[bot]' && github.event.pull_request.user.type == 'Bot' && github.event.pull_request.head.ref == 'release-please--branches--main--components--illo' }}
+        run: |
+          args=(--base "$BASE_SHA" --head "$HEAD_SHA")
+          if [[ "$TRUSTED_RELEASE_PR" == "true" ]]; then
+            args+=(--trusted-release-pr)
+          fi
+          python3 .github/scripts/validate_pr_commits.py "${args[@]}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,6 +250,9 @@ all PRs, including forks. Allowed types are `feat`, `fix`, `perf`, `revert`,
 `docs`, `style`, `refactor`, `test`, `build`, `ci`, and `chore`. If a PR changes
 anything under `skills/illo/**`, at least one non-merge commit must use
 `feat:`, `fix:`, `perf:`, or `revert:` so Release Please sees a release trigger.
+The generated Release Please PR is exempt from that release-trigger subset only
+when its event identifies the exact same-repo release branch and GitHub Actions
+bot author; its generated commit and PR title must still be Conventional.
 Use `docs:`, `chore:`, or `ci:` as appropriate for repo-only changes that
 should not trigger a skill release.
 

--- a/tests/test_validate_pr_commits.py
+++ b/tests/test_validate_pr_commits.py
@@ -79,6 +79,34 @@ class PullRequestCommitValidationTests(unittest.TestCase):
         self.assertEqual(len(errors), 1)
         self.assertIn("require at least one", errors[0])
 
+    def test_trusted_generated_release_metadata_is_valid(self):
+        errors = self.validator.validate(
+            [self.commit("chore(main): release 0.31.6")],
+            ["skills/illo/SKILL.md", "version.txt"],
+            trusted_release_pr=True,
+        )
+
+        self.assertEqual(errors, [])
+
+    def test_fork_like_release_metadata_without_trusted_mode_is_rejected(self):
+        errors = self.validator.validate(
+            [self.commit("chore(main): release 0.31.6")],
+            ["skills/illo/SKILL.md", "version.txt"],
+        )
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("require at least one", errors[0])
+
+    def test_trusted_generated_release_still_requires_conventional_subject(self):
+        errors = self.validator.validate(
+            [self.commit("release 0.31.6")],
+            ["skills/illo/SKILL.md", "version.txt"],
+            trusted_release_pr=True,
+        )
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("non-conventional", errors[0])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- keep Conventional Commit validation for every PR title and non-merge commit
- allow Release Please's generated `chore(main): release <version>` commit to update installed skill files without requiring a second `feat:`, `fix:`, `perf:`, or `revert:` commit
- grant that narrow mode only when the PR has all trusted signals: the exact same repository, the GitHub Actions bot author/type, and the exact Release Please branch for `main`/`illo`
- add regressions for the trusted release case, a fork-like untrusted case, and malformed generated metadata

## Why

Release Please normally opens its release PR with `GITHUB_TOKEN`, which suppresses follow-on workflow execution. The repository also supports a `RELEASE_PLEASE_TOKEN` PAT so protected branches can require checks on generated release PRs. With that PAT configured, the Conventional PR metadata workflow would run and reject Release Please's legitimate generated commit because `skills/illo/SKILL.md` changes currently require a release-triggering commit type.

This change does not skip commit validation. The trusted mode only removes the installed-skill release-trigger subset requirement; generated commits must still pass the existing Conventional Commit subject regex, and PR titles continue through the existing title job. A fork that copies the Release Please branch name cannot receive the mode because its head repository does not match the base repository.

## Verification

- `python3 -m unittest discover -s tests -v` — 34 tests passed
- `python3 .github/scripts/validate_pr_commits.py --base origin/main --head origin/release-please--branches--main--components--illo --trusted-release-pr` — accepted the current generated release commit
- the same command without `--trusted-release-pr` — rejected with exit code 1 and the installed-skill release-trigger error
- `python3 .github/scripts/validate_pr_commits.py --base origin/main --head HEAD` — validated this PR's single `ci:` commit
- `python3 .github/scripts/sync_plugin_versions.py --check` — all manifests at 0.31.5
- `python3 .github/scripts/regen_asset_checksums.py --check` — checksums.txt is current
- `python3 -m py_compile .github/scripts/validate_pr_commits.py tests/test_validate_pr_commits.py` — passed
- `git diff --check origin/main...HEAD` — passed

## Risk

Low. The exception is workflow-only, requires all trusted event signals, and preserves both Conventional title and commit validation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change with strict PR event gates; conventional commit validation is unchanged aside from the narrow release-trigger waiver.
> 
> **Overview**
> Adds a **trusted Release Please** path so generated release PRs can touch `skills/illo/**` without a `feat`/`fix`/`perf`/`revert` commit, while keeping full Conventional Commit validation.
> 
> `validate_pr_commits.py` gains `--trusted-release-pr` and skips only the installed-skill release-trigger rule when that flag is set; conventional subject checks still apply. The **Conventional PR metadata** workflow sets the flag when the PR is same-repo, authored by `github-actions[bot]`, and on the exact `release-please--branches--main--components--illo` branch. **AGENTS.md** documents the exemption. New unit tests cover trusted acceptance, untrusted rejection, and non-conventional subjects under trusted mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8009e02ebb39ccada741d0a960af220cd99176c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->