### PR TITLE
fix: don't narrate illo workflow

### DIFF
--- a/skills/illo/SKILL.md
+++ b/skills/illo/SKILL.md
@@ -697,3 +697,9 @@ Before the final reply in a chat session, check:
 Pre-generation planning is short and concrete. Post-generation, let the images
 speak — report what was made and where, not style theory. Keep labels few and
 short; the fewer words baked into an image, the more reliably it renders.
+
+Talk like a person doing the work, not a recap of this file. Never narrate
+workflow steps or jargon in chat: doctor, preflight, provenance, register,
+saying bar, thesis, backend, or "doctor's green." Status, if any, is ordinary
+speech ("Wick, three quotes"), not a liturgy of steps. The user hears the
+result — character, sayings / image, what was made — not the procedure.

--- a/skills/illo/references/surprise.md
+++ b/skills/illo/references/surprise.md
@@ -493,11 +493,7 @@ shot-list / structure rules.
 
 ## Delivery
 
-Keep the procedure internal: never narrate doctor, preflight, provenance,
-register, saying bar, or thesis in chat, and never say "doctor's green." The
-user hears the character name, the three sayings (then the picker), then the
-locked saying + image; status, if any, is ordinary speech ("Wick, three
-quotes"), not workflow recap.
+Follow SKILL.md Output discipline; do not narrate this procedure.
 
 Always report, next to the image (path or chat media per Step 7):
 

--- a/skills/illo/references/surprise.md
+++ b/skills/illo/references/surprise.md
@@ -493,6 +493,12 @@ shot-list / structure rules.
 
 ## Delivery
 
+Keep the procedure internal: never narrate doctor, preflight, provenance,
+register, saying bar, or thesis in chat, and never say "doctor's green." The
+user hears the character name, the three sayings (then the picker), then the
+locked saying + image; status, if any, is ordinary speech ("Wick, three
+quotes"), not workflow recap.
+
 Always report, next to the image (path or chat media per Step 7):
 
 - the **saying** first — full shareable caption


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Agents were leaking liturgy into chat globally, including Step 0 "doctor's green" status; this keeps workflow procedure internal across paths.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-befc112e-8e5b-40ab-b218-8347ae1a9cc1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-befc112e-8e5b-40ab-b218-8347ae1a9cc1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

