### PR TITLE
fix: keep successful chroma cutouts transparent

### DIFF
--- a/skills/illo/SKILL.md
+++ b/skills/illo/SKILL.md
@@ -77,6 +77,7 @@ infographic, not a formal flowchart, not a UI mockup.
 | **Options to pick from, or "which model is best"** | Step 5b: `--count` variations or a model loop → `gallery` with a recommendation. |
 | **Fix an existing image** (stray title, recolor, mascot too decorative) | Edit prompts in `references/prompt-recipe.md`, passing the image back as `--ref`. |
 | **Character cutout / transparent PNG / overlay sticker** — "just the mascot", "no background", "paste on something else" | The **cutout register** (`references/cutout.md`): read in full, prompt from `references/prompt-recipe.md` "Cutout variant", generate with `--cutout` and `--aspect 1:1`. OpenRouter cutouts default to GPT Image 2 (not Grok). Not for explaining an idea — reroute to editorial if the ask needs a scene. |
+| **Animated idle / bot avatar / looping GIF of the mascot** | The **cutout register** plus `references/cutout.md`, "Idle loop / bot avatar": one transparent 1:1 cutout with `--cutout` and the character sheet as `--ref`, then programmatic motion on that PNG. |
 
 ## Prerequisites
 

--- a/skills/illo/references/cutout.md
+++ b/skills/illo/references/cutout.md
@@ -231,3 +231,43 @@ Do **not** use Pillow `save(..., optimize=True, disposal=2)` for this path; it
 can drop alpha on blink frames and flash a black background. Deliver 1:1, loop
 forever, keep the character about 60-80% of the frame, and stay under 5 MB for
 Grok Bot avatars.
+
+Before delivery, inspect the source cutout, at least three exported frames
+(rest, max bob, blink), and the final GIF. Do not ship from the script
+succeeding.
+
+### Must pass
+
+- **Look at the pixels** — open the cutout and GIF; tight-crop thin parts
+  (antenna, stems, outlines) instead of trusting generate JSON or ffmpeg exit
+  status.
+- **Transparency on every frame** — corners stay transparent; no frame has
+  nearly zero transparent pixels.
+- **Thin-part geometry** — antenna / accent stem stays straight and centered on
+  its ball or tip.
+- **Blink stays on-model** — the pack face lock still holds; blink by squashing
+  the locked eye dots only, with no invented mouth/brows.
+- **Motion is visible but planted** — on a 512 canvas, rest vs max-bob head-top
+  Y moves about 8-12 px (~1.5-2.5% of the canvas); the body and feet Y stay
+  unchanged.
+- **One cutout** — every frame comes from the same still PNG, not morphed
+  separately generated poses.
+- **Watch the loop once** — if the personality is not noticeable, or a tear is
+  noticeable, it is not ready.
+
+### Fail signals → fix
+
+- A frame has nearly zero transparent pixels, or the GIF flashes black →
+  re-encode with the ffmpeg palettegen path above; never use Pillow
+  `optimize=True` for this path.
+- Antenna / accent stem drifts 1-2 px down the shaft, bends, or misses the
+  ball/tip center → straighten in post or re-roll the still.
+- Whole sticker rotates, hops, or bounces → keep the body planted; animate
+  head/eyes personality only.
+- Head bob under ~4 px on a 512 canvas → increase it; the motion will disappear
+  at delivery size.
+- Head lifts off the torso, leaves a gap, sliced chin, double contour, or
+  leftover chin slab → bob **down into the body only**, feather the join, and
+  keep enough overlap.
+- Blink frame invents facial features or changes expression → rebuild it as
+  locked eye-dot squash only.

--- a/skills/illo/references/cutout.md
+++ b/skills/illo/references/cutout.md
@@ -197,3 +197,37 @@ character sheet alone.
 Check against the cutout section of `references/quality-bar.md` before
 delivering. Re-roll on orphans, scene bleed, green fringing, cropped feet/limbs,
 or off-model drift.
+
+## Idle loop / bot avatar
+
+Route animated idle loops and bot-avatar GIFs through this same **cutout**
+register: 1:1, `--cutout`, active character sheet as `--ref`. Do not route to
+editorial.
+
+Generate **one** on-model cutout and animate that PNG. Do **not** generate 3-4
+poses and morph them — separate renders drift and the loop flickers. Keep the
+pack constraints programmatic: no mouth/brows means do not draw them; blink by
+squashing the locked eye dots; no fingers means no grasping wave; a deadpan face
+stays deadpan.
+
+For a head bob, move **only the head** plus antenna; keep the body planted.
+Prefer down into the body and back, or a feathered join with enough overlap.
+Lifting the head off the torso exposes a sliced chin / double contour. Make the
+motion subtle but visible: about 8-12 px on a 512 canvas. A 2 px move vanishes;
+12 px in both directions tends to tear.
+
+Trust `cutout_alpha` after the engine runs. If a keyed PNG is discarded even
+though the corners are transparent and the background is gone, that is an engine
+bug — do not "fix" it by switching to Grok Bot native, which has no alpha.
+
+Encode transparent GIFs with ffmpeg palette preservation:
+
+```bash
+ffmpeg -i frames/%03d.png -vf "palettegen=reserve_transparent=1" palette.png
+ffmpeg -i frames/%03d.png -i palette.png -lavfi "paletteuse=dither=none" -loop 0 avatar.gif
+```
+
+Do **not** use Pillow `save(..., optimize=True, disposal=2)` for this path; it
+can drop alpha on blink frames and flash a black background. Deliver 1:1, loop
+forever, keep the character about 60-80% of the frame, and stay under 5 MB for
+Grok Bot avatars.

--- a/skills/illo/references/cutout.md
+++ b/skills/illo/references/cutout.md
@@ -210,11 +210,23 @@ pack constraints programmatic: no mouth/brows means do not draw them; blink by
 squashing the locked eye dots; no fingers means no grasping wave; a deadpan face
 stays deadpan.
 
-For a head bob, move **only the head** plus antenna; keep the body planted.
-Prefer down into the body and back, or a feathered join with enough overlap.
-Lifting the head off the torso exposes a sliced chin / double contour. Make the
-motion subtle but visible: about 8-12 px on a 512 canvas. A 2 px move vanishes;
-12 px in both directions tends to tear.
+Pick the move from the figure. Read the pack's locked design, accent carrier,
+and limbs; choose one or more motions that figure can do without breaking locks.
+Head bob is optional: allowed when the silhouette has a distinct head that can
+nod **down into the body** without tearing. Use about 8-12 px on a 512 canvas,
+down-only, with a feathered join and the body planted. It can stack with another
+move (blink, antenna sway, flame flicker) or be the only move. It is not
+required.
+
+Other pack-legal examples (illustrative, not exhaustive):
+
+- Soft blob / droplet (Blot) — jelly squash of the body; tip rides the squash;
+  feet planted.
+- Rigid cube + antenna (Blip) — antenna sway; cube planted.
+- Accent flame / lantern (Wick) — flame flicker only; iron planted.
+- Accordion / spring limbs (Coil) — limb compress-and-rebound; head/torso/feet
+  planted.
+- Blink — squash locked eye dots only, on any pack that has them. Combine freely.
 
 Trust `cutout_alpha` after the engine runs. If a keyed PNG is discarded even
 though the corners are transparent and the background is gone, that is an engine
@@ -233,8 +245,8 @@ forever, keep the character about 60-80% of the frame, and stay under 5 MB for
 Grok Bot avatars.
 
 Before delivery, inspect the source cutout, at least three exported frames
-(rest, max bob, blink), and the final GIF. Do not ship from the script
-succeeding.
+(rest, peak motion, blink if present; otherwise another changed frame), and the
+final GIF. Do not ship from the script succeeding.
 
 ### Must pass
 
@@ -247,9 +259,10 @@ succeeding.
   its ball or tip.
 - **Blink stays on-model** — the pack face lock still holds; blink by squashing
   the locked eye dots only, with no invented mouth/brows.
-- **Motion is visible but planted** — on a 512 canvas, rest vs max-bob head-top
-  Y moves about 8-12 px (~1.5-2.5% of the canvas); the body and feet Y stay
-  unchanged.
+- **Motion is pack-legal, visible, and planted** — the chosen move comes from
+  the silhouette, accent carrier, or locked limbs. If using a head bob on a 512
+  canvas, rest vs peak head-top Y moves about 8-12 px (~1.5-2.5% of the canvas),
+  down-only. Body/feet/contact stay planted.
 - **One cutout** — every frame comes from the same still PNG, not morphed
   separately generated poses.
 - **Watch the loop once** — if the personality is not noticeable, or a tear is
@@ -262,12 +275,14 @@ succeeding.
   `optimize=True` for this path.
 - Antenna / accent stem drifts 1-2 px down the shaft, bends, or misses the
   ball/tip center → straighten in post or re-roll the still.
-- Whole sticker rotates, hops, or bounces → keep the body planted; animate
-  head/eyes personality only.
-- Head bob under ~4 px on a 512 canvas → increase it; the motion will disappear
-  at delivery size.
+- Whole sticker rotates, hops, or bounces → keep contact planted; animate only
+  pack-legal silhouette parts.
+- Head bob under ~4 px on a 512 canvas → increase it or choose a better
+  pack-legal move; the motion will disappear at delivery size.
 - Head lifts off the torso, leaves a gap, sliced chin, double contour, or
-  leftover chin slab → bob **down into the body only**, feather the join, and
-  keep enough overlap.
+  leftover chin slab → if using a bob, move **down into the body only**, feather
+  the join, and keep enough overlap.
 - Blink frame invents facial features or changes expression → rebuild it as
   locked eye-dot squash only.
+- Every avatar in a multi-bot set uses the same generic head bob when a
+  pack-legal alternative exists → choose distinct moves from each figure.

--- a/skills/illo/references/quality-bar.md
+++ b/skills/illo/references/quality-bar.md
@@ -157,8 +157,8 @@ style QA deltas) still applies to the character cluster.
 - **Pose matches the ask** — gesture, facing, and attitude match what was
   requested (or the agent's inferred pose when the prompt was thin).
 - **Idle-loop GIFs** — after this cutout QA, run `references/cutout.md`, "Idle
-  loop / bot avatar" on the source cutout, rest/max-bob/blink frames, and final
-  GIF.
+  loop / bot avatar" on the source cutout, rest/peak-motion/blink-or-other
+  changed frames, and final GIF.
 
 ### Fail signals → fix
 

--- a/skills/illo/references/quality-bar.md
+++ b/skills/illo/references/quality-bar.md
@@ -156,6 +156,9 @@ style QA deltas) still applies to the character cluster.
 - **One compositing unit** — reads as one sticker, not a cropped illustration.
 - **Pose matches the ask** — gesture, facing, and attitude match what was
   requested (or the agent's inferred pose when the prompt was thin).
+- **Idle-loop GIFs** — after this cutout QA, run `references/cutout.md`, "Idle
+  loop / bot avatar" on the source cutout, rest/max-bob/blink frames, and final
+  GIF.
 
 ### Fail signals → fix
 

--- a/skills/illo/references/quality-bar.md
+++ b/skills/illo/references/quality-bar.md
@@ -165,7 +165,8 @@ style QA deltas) still applies to the character cluster.
 - Edge-only accent-colored halo tracing the outer contour (riso
   misregistration) → re-roll with the **registration-locked SILHOUETTE** block —
   no ink-layer offset on cutouts (`references/prompt-recipe.md`, "Cutout
-  variant"). Interior accent fill is correct on-model, not a halo.
+  variant"). Interior accent fill and compact locked accent carriers that touch
+  air are correct on-model, not halos.
 - Feet or base cropped by the frame → re-roll; check the Composition line names
   full body and margin below the feet.
 - A separate object sits near but not touching the character → re-roll

--- a/skills/illo/references/quality-bar.md
+++ b/skills/illo/references/quality-bar.md
@@ -133,11 +133,12 @@ style QA deltas) still applies to the character cluster.
 
 ### Must pass
 
-- **Transparent output** — manifest `cutout_alpha` is true (engine requires clean
-  alpha: transparent corners and sufficient background removal). No visible
-  magenta/green screen fringing at the silhouette edge. When `cutout_alpha` is false,
-  do not deliver as a compositing sticker — re-roll, switch backend/model, or
-  disclose honestly (see `cutout_note`).
+- **Transparent output** — manifest `cutout_alpha` is true (transparent corners
+  and sufficient background removal). No visible magenta/green screen fringing at
+  the silhouette edge. Interior accent fill is not a fringe fail; when corners
+  are transparent and the background is gone, `cutout_alpha` must stay true. When
+  `cutout_alpha` is false, do not deliver as a compositing sticker — re-roll,
+  switch backend/model, or disclose honestly (see `cutout_note`).
 - **Full body framing** — feet/base fully visible, not cropped by the frame; clear
   margin below the feet (same structural-integrity bar as editorial limbs). The
   engine flags likely crops in `cutout_note` ("character touches the bottom frame
@@ -161,9 +162,10 @@ style QA deltas) still applies to the character cluster.
 - Green or magenta bleed on the silhouette → re-roll with the **other** chroma
   screen (see `references/cutout.md`); check `--cutout` was passed and the
   BACKGROUND line matches the character.
-- Accent-colored halo tracing the outer contour (riso misregistration) → re-roll
-  with the **registration-locked SILHOUETTE** block — no ink-layer offset on
-  cutouts (`references/prompt-recipe.md`, "Cutout variant").
+- Edge-only accent-colored halo tracing the outer contour (riso
+  misregistration) → re-roll with the **registration-locked SILHOUETTE** block —
+  no ink-layer offset on cutouts (`references/prompt-recipe.md`, "Cutout
+  variant"). Interior accent fill is correct on-model, not a halo.
 - Feet or base cropped by the frame → re-roll; check the Composition line names
   full body and margin below the feet.
 - A separate object sits near but not touching the character → re-roll

--- a/skills/illo/scripts/illo.py
+++ b/skills/illo/scripts/illo.py
@@ -45,8 +45,9 @@ CHROMA_SOFT = 20
 CHROMA_SPILL_MIN = 18   # channel dominance over the other two → spill candidate
 CHROMA_SPILL_FLOOR = 45 # ignore tiny channel noise on very dark pixels
 CHROMA_SPILL_STRONG = 30  # dominance this high keys even when G is below floor
-# Cutout QA hints on a clean-alpha output (warnings, never gate cutout_alpha):
-CUTOUT_FRINGE_WARN = 20   # fringe px below the clean-alpha gate but worth a QA look
+# Cutout QA hints on a transparent output (warnings, never gate cutout_alpha):
+CUTOUT_ALPHA_MIN_TRANSPARENT = 1000  # enough cleared background to trust the alpha
+CUTOUT_FRINGE_WARN = 20   # edge-fringe px worth a QA look
 CUTOUT_EDGE_FRAC = 0.02   # opaque px along the bottom row over this frac of width →
                           # character likely touches/crops the frame (no foot margin)
 # Grok Imagine: best riso quality + cheapest in testing. Note: it is reachable via
@@ -552,10 +553,27 @@ def _is_spill_halo(r, g, b):
 
 
 def _is_accent_halo(r, g, b, a):
-    """Riso misregistration / accent ink tracing the outer silhouette."""
+    """Accent ink color that may be a halo when it sits on the outer edge."""
     if a == 0:
         return False
     return r > 150 and g < 110 and b > 80 and r > g + 35
+
+
+def _touches_transparency(rgba, width, height, x, y):
+    """Whether an opaque pixel sits on the alpha boundary."""
+    for dy in (-1, 0, 1):
+        ny = y + dy
+        if ny < 0 or ny >= height:
+            continue
+        for dx in (-1, 0, 1):
+            if dx == 0 and dy == 0:
+                continue
+            nx = x + dx
+            if nx < 0 or nx >= width:
+                continue
+            if rgba[(ny * width + nx) * 4 + 3] == 0:
+                return True
+    return False
 
 
 def _despill_rgb(r, g, b, a):
@@ -620,7 +638,7 @@ def chroma_key_to_png(data, key=CHROMA_KEY):
 
 
 def analyze_cutout_alpha(img_bytes):
-    """Return transparency metrics for cutout QA and routing."""
+    """Return transparency metrics for cutout routing plus edge-fringe QA."""
     ext = sniff_ext(img_bytes)
     w, h = image_size(img_bytes)
     out = {"ext": ext, "width": w, "height": h, "transparent": 0, "opaque": 0,
@@ -641,11 +659,15 @@ def analyze_cutout_alpha(img_bytes):
             out["opaque"] += 1
         else:
             out["semi"] += 1
-        if a and g > max(r, b) + 10 and g > 45:
+        x = (i // 4) % w
+        y = (i // 4) // w
+        edge_pixel = a and _touches_transparency(rgba, w, h, x, y)
+        if edge_pixel and g > max(r, b) + 10 and g > 45:
             out["green_fringe"] += 1
-        if a and r > 120 and b > 120 and r > g + 15 and b > g + 15 and abs(r - b) < 60:
+        if (edge_pixel and r > 120 and b > 120 and r > g + 15 and b > g + 15
+                and abs(r - b) < 60):
             out["magenta_fringe"] += 1
-        if a and _is_accent_halo(r, g, b, a):
+        if edge_pixel and _is_accent_halo(r, g, b, a):
             out["accent_halo"] += 1
     corners = [(0, 0), (w - 1, 0), (0, h - 1), (w - 1, h - 1)]
     out["corner_alpha"] = [rgba[(y * w + x) * 4 + 3] for x, y in corners]
@@ -653,8 +675,8 @@ def analyze_cutout_alpha(img_bytes):
     out["bottom_edge_opaque"] = sum(1 for x in range(w) if rgba[(bottom + x) * 4 + 3])
     out["has_alpha"] = out["transparent"] > 0 or out["semi"] > 0
     out["fringe"] = out["green_fringe"] + out["magenta_fringe"] + out["accent_halo"]
-    out["clean_alpha"] = (out["transparent"] > 1000 and all(a == 0 for a in out["corner_alpha"])
-                          and out["fringe"] < 50)
+    out["clean_alpha"] = (out["transparent"] > CUTOUT_ALPHA_MIN_TRANSPARENT
+                          and all(a == 0 for a in out["corner_alpha"]))
     return out
 
 
@@ -829,7 +851,7 @@ def _place_opaque(img_bytes, out_path):
 
 
 def _cutout_quality_note(analysis):
-    """QA warnings for a clean-alpha cutout. These never gate cutout_alpha —
+    """QA warnings for an alpha cutout. These never gate cutout_alpha —
     transparency is real; the agent re-rolls on framing/fringe at QA."""
     notes = []
     w = analysis.get("width") or 0

--- a/skills/illo/scripts/illo.py
+++ b/skills/illo/scripts/illo.py
@@ -47,6 +47,8 @@ CHROMA_SPILL_FLOOR = 45 # ignore tiny channel noise on very dark pixels
 CHROMA_SPILL_STRONG = 30  # dominance this high keys even when G is below floor
 # Cutout QA hints on a transparent output (warnings, never gate cutout_alpha):
 CUTOUT_ALPHA_MIN_TRANSPARENT = 1000  # enough cleared background to trust the alpha
+CUTOUT_EDGE_ALPHA = 128  # soft alpha below this still counts as outside for edge QA
+CUTOUT_ACCENT_HALO_EDGE_FRAC = 0.25  # compact locked accent carriers are not halos
 CUTOUT_FRINGE_WARN = 20   # edge-fringe px worth a QA look
 CUTOUT_EDGE_FRAC = 0.02   # opaque px along the bottom row over this frac of width →
                           # character likely touches/crops the frame (no foot margin)
@@ -560,7 +562,11 @@ def _is_accent_halo(r, g, b, a):
 
 
 def _touches_transparency(rgba, width, height, x, y):
-    """Whether an opaque pixel sits on the alpha boundary."""
+    """Whether an opaque pixel sits on the alpha boundary.
+
+    Semi-transparent chroma edge pixels are outside enough for QA: a fringe just
+    behind a soft alpha ring should still be visible to the warning pass.
+    """
     for dy in (-1, 0, 1):
         ny = y + dy
         if ny < 0 or ny >= height:
@@ -571,7 +577,7 @@ def _touches_transparency(rgba, width, height, x, y):
             nx = x + dx
             if nx < 0 or nx >= width:
                 continue
-            if rgba[(ny * width + nx) * 4 + 3] == 0:
+            if rgba[(ny * width + nx) * 4 + 3] < CUTOUT_EDGE_ALPHA:
                 return True
     return False
 
@@ -651,6 +657,8 @@ def analyze_cutout_alpha(img_bytes):
     if not parsed:
         return out
     w, h, rgba = parsed
+    edge_pixels = 0
+    accent_edge = 0
     for i in range(0, len(rgba), 4):
         r, g, b, a = rgba[i:i + 4]
         if a == 0:
@@ -662,18 +670,25 @@ def analyze_cutout_alpha(img_bytes):
         x = (i // 4) % w
         y = (i // 4) // w
         edge_pixel = a and _touches_transparency(rgba, w, h, x, y)
+        if edge_pixel:
+            edge_pixels += 1
         if edge_pixel and g > max(r, b) + 10 and g > 45:
             out["green_fringe"] += 1
         if (edge_pixel and r > 120 and b > 120 and r > g + 15 and b > g + 15
                 and abs(r - b) < 60):
             out["magenta_fringe"] += 1
         if edge_pixel and _is_accent_halo(r, g, b, a):
-            out["accent_halo"] += 1
+            accent_edge += 1
     corners = [(0, 0), (w - 1, 0), (0, h - 1), (w - 1, h - 1)]
     out["corner_alpha"] = [rgba[(y * w + x) * 4 + 3] for x, y in corners]
     bottom = (h - 1) * w
     out["bottom_edge_opaque"] = sum(1 for x in range(w) if rgba[(bottom + x) * 4 + 3])
     out["has_alpha"] = out["transparent"] > 0 or out["semi"] > 0
+    # Accent ink touching air is often correct (antenna balls, droplet tips).
+    # Warn only when it behaves like a misregistered ring around much of the silhouette.
+    if edge_pixels and accent_edge >= max(CUTOUT_FRINGE_WARN,
+                                         int(edge_pixels * CUTOUT_ACCENT_HALO_EDGE_FRAC)):
+        out["accent_halo"] = accent_edge
     out["fringe"] = out["green_fringe"] + out["magenta_fringe"] + out["accent_halo"]
     out["clean_alpha"] = (out["transparent"] > CUTOUT_ALPHA_MIN_TRANSPARENT
                           and all(a == 0 for a in out["corner_alpha"]))

--- a/skills/illo/scripts/illo.py
+++ b/skills/illo/scripts/illo.py
@@ -47,6 +47,7 @@ CHROMA_SPILL_FLOOR = 45 # ignore tiny channel noise on very dark pixels
 CHROMA_SPILL_STRONG = 30  # dominance this high keys even when G is below floor
 # Cutout QA hints on a transparent output (warnings, never gate cutout_alpha):
 CUTOUT_ALPHA_MIN_TRANSPARENT = 1000  # enough cleared background to trust the alpha
+CUTOUT_SOFT_EDGE_MAX = 8  # max soft-alpha path length from true transparency
 CUTOUT_ACCENT_HALO_EDGE_FRAC = 0.25  # compact locked accent carriers are not halos
 CUTOUT_FRINGE_WARN = 20   # edge-fringe px worth a QA look
 CUTOUT_EDGE_FRAC = 0.02   # opaque px along the bottom row over this frac of width →
@@ -560,13 +561,7 @@ def _is_accent_halo(r, g, b, a):
     return r > 150 and g < 110 and b > 80 and r > g + 35
 
 
-def _touches_transparency(rgba, width, height, x, y):
-    """Whether an opaque pixel sits on the alpha boundary.
-
-    Outside is true transparency (alpha 0). A fringe just behind a one-pixel
-    soft alpha ring still counts as edge; interior soft patches do not.
-    """
-    soft_neighbors = []
+def _neighbor_coords(width, height, x, y):
     for dy in (-1, 0, 1):
         ny = y + dy
         if ny < 0 or ny >= height:
@@ -577,24 +572,54 @@ def _touches_transparency(rgba, width, height, x, y):
             nx = x + dx
             if nx < 0 or nx >= width:
                 continue
-            alpha = rgba[(ny * width + nx) * 4 + 3]
-            if alpha == 0:
-                return True
-            if alpha < 255:
-                soft_neighbors.append((nx, ny))
-    for sx, sy in soft_neighbors:
-        for dy in (-1, 0, 1):
-            ny = sy + dy
-            if ny < 0 or ny >= height:
+            yield nx, ny
+
+
+def _soft_near_air_mask(rgba, width, height, max_depth=CUTOUT_SOFT_EDGE_MAX):
+    """Soft alpha pixels connected to true transparency within max_depth."""
+    mask = bytearray(width * height)
+    queue = []
+    for idx in range(width * height):
+        alpha = rgba[idx * 4 + 3]
+        if not 0 < alpha < 255:
+            continue
+        x = idx % width
+        y = idx // width
+        for nx, ny in _neighbor_coords(width, height, x, y):
+            if rgba[(ny * width + nx) * 4 + 3] == 0:
+                mask[idx] = 1
+                queue.append((x, y, 1))
+                break
+    head = 0
+    while head < len(queue):
+        x, y, depth = queue[head]
+        head += 1
+        if depth >= max_depth:
+            continue
+        for nx, ny in _neighbor_coords(width, height, x, y):
+            nidx = ny * width + nx
+            if mask[nidx]:
                 continue
-            for dx in (-1, 0, 1):
-                if dx == 0 and dy == 0:
-                    continue
-                nx = sx + dx
-                if nx < 0 or nx >= width:
-                    continue
-                if rgba[(ny * width + nx) * 4 + 3] == 0:
-                    return True
+            alpha = rgba[nidx * 4 + 3]
+            if 0 < alpha < 255:
+                mask[nidx] = 1
+                queue.append((nx, ny, depth + 1))
+    return mask
+
+
+def _touches_transparency(rgba, width, height, x, y, soft_near_air):
+    """Whether an opaque pixel sits on the alpha boundary.
+
+    Outside is true transparency (alpha 0). Soft alpha counts only when the
+    precomputed mask proves it has a bounded path to air.
+    """
+    for nx, ny in _neighbor_coords(width, height, x, y):
+        idx = ny * width + nx
+        alpha = rgba[idx * 4 + 3]
+        if alpha == 0:
+            return True
+        if 0 < alpha < 255 and soft_near_air[idx]:
+            return True
     return False
 
 
@@ -673,6 +698,7 @@ def analyze_cutout_alpha(img_bytes):
     if not parsed:
         return out
     w, h, rgba = parsed
+    soft_near_air = _soft_near_air_mask(rgba, w, h)
     edge_pixels = 0
     accent_edge = 0
     for i in range(0, len(rgba), 4):
@@ -685,7 +711,7 @@ def analyze_cutout_alpha(img_bytes):
             out["semi"] += 1
         x = (i // 4) % w
         y = (i // 4) // w
-        edge_pixel = a and _touches_transparency(rgba, w, h, x, y)
+        edge_pixel = a and _touches_transparency(rgba, w, h, x, y, soft_near_air)
         if edge_pixel:
             edge_pixels += 1
         if edge_pixel and g > max(r, b) + 10 and g > 45:

--- a/skills/illo/scripts/illo.py
+++ b/skills/illo/scripts/illo.py
@@ -47,7 +47,6 @@ CHROMA_SPILL_FLOOR = 45 # ignore tiny channel noise on very dark pixels
 CHROMA_SPILL_STRONG = 30  # dominance this high keys even when G is below floor
 # Cutout QA hints on a transparent output (warnings, never gate cutout_alpha):
 CUTOUT_ALPHA_MIN_TRANSPARENT = 1000  # enough cleared background to trust the alpha
-CUTOUT_EDGE_ALPHA = 128  # soft alpha below this still counts as outside for edge QA
 CUTOUT_ACCENT_HALO_EDGE_FRAC = 0.25  # compact locked accent carriers are not halos
 CUTOUT_FRINGE_WARN = 20   # edge-fringe px worth a QA look
 CUTOUT_EDGE_FRAC = 0.02   # opaque px along the bottom row over this frac of width →
@@ -564,9 +563,10 @@ def _is_accent_halo(r, g, b, a):
 def _touches_transparency(rgba, width, height, x, y):
     """Whether an opaque pixel sits on the alpha boundary.
 
-    Semi-transparent chroma edge pixels are outside enough for QA: a fringe just
-    behind a soft alpha ring should still be visible to the warning pass.
+    Outside is true transparency (alpha 0). A fringe just behind a one-pixel
+    soft alpha ring still counts as edge; interior soft patches do not.
     """
+    soft_neighbors = []
     for dy in (-1, 0, 1):
         ny = y + dy
         if ny < 0 or ny >= height:
@@ -577,8 +577,24 @@ def _touches_transparency(rgba, width, height, x, y):
             nx = x + dx
             if nx < 0 or nx >= width:
                 continue
-            if rgba[(ny * width + nx) * 4 + 3] < CUTOUT_EDGE_ALPHA:
+            alpha = rgba[(ny * width + nx) * 4 + 3]
+            if alpha == 0:
                 return True
+            if alpha < 255:
+                soft_neighbors.append((nx, ny))
+    for sx, sy in soft_neighbors:
+        for dy in (-1, 0, 1):
+            ny = sy + dy
+            if ny < 0 or ny >= height:
+                continue
+            for dx in (-1, 0, 1):
+                if dx == 0 and dy == 0:
+                    continue
+                nx = sx + dx
+                if nx < 0 or nx >= width:
+                    continue
+                if rgba[(ny * width + nx) * 4 + 3] == 0:
+                    return True
     return False
 
 

--- a/skills/illo/scripts/illo.py
+++ b/skills/illo/scripts/illo.py
@@ -712,14 +712,15 @@ def analyze_cutout_alpha(img_bytes):
         x = (i // 4) % w
         y = (i // 4) // w
         edge_pixel = a and _touches_transparency(rgba, w, h, x, y, soft_near_air)
-        if edge_pixel:
+        opaque_edge_pixel = edge_pixel and a == 255
+        if opaque_edge_pixel:
             edge_pixels += 1
         if edge_pixel and g > max(r, b) + 10 and g > 45:
             out["green_fringe"] += 1
         if (edge_pixel and r > 120 and b > 120 and r > g + 15 and b > g + 15
                 and abs(r - b) < 60):
             out["magenta_fringe"] += 1
-        if edge_pixel and _is_accent_halo(r, g, b, a):
+        if opaque_edge_pixel and _is_accent_halo(r, g, b, a):
             accent_edge += 1
     corners = [(0, 0), (w - 1, 0), (0, h - 1), (w - 1, h - 1)]
     out["corner_alpha"] = [rgba[(y * w + x) * 4 + 3] for x, y in corners]
@@ -727,7 +728,7 @@ def analyze_cutout_alpha(img_bytes):
     out["bottom_edge_opaque"] = sum(1 for x in range(w) if rgba[(bottom + x) * 4 + 3])
     out["has_alpha"] = out["transparent"] > 0 or out["semi"] > 0
     # Accent ink touching air is often correct (antenna balls, droplet tips).
-    # Warn only when it behaves like a misregistered ring around much of the silhouette.
+    # Opaque edge pixels define this denominator; soft mattes must not dilute it.
     if edge_pixels and accent_edge >= max(CUTOUT_FRINGE_WARN,
                                          int(edge_pixels * CUTOUT_ACCENT_HALO_EDGE_FRAC)):
         out["accent_halo"] = accent_edge

--- a/tests/test_cutout_chroma.py
+++ b/tests/test_cutout_chroma.py
@@ -1,0 +1,111 @@
+import importlib.util
+import struct
+import tempfile
+import unittest
+import zlib
+from pathlib import Path
+from typing import Any, cast
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "skills" / "illo" / "scripts" / "illo.py"
+
+MAGENTA = (255, 0, 255)
+CREAM = (248, 234, 205)
+PINK = (255, 61, 154)
+
+
+def load_illo_module():
+    spec = importlib.util.spec_from_file_location("illo_script_under_test", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load illo script from {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return cast(Any, module)
+
+
+def rgb_png(width, height, pixels):
+    raw_rows = bytearray()
+    for y in range(height):
+        raw_rows.append(0)
+        for x in range(width):
+            raw_rows.extend(pixels[y * width + x])
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+
+    def chunk(kind, data):
+        return (struct.pack(">I", len(data)) + kind + data
+                + struct.pack(">I", zlib.crc32(kind + data) & 0xffffffff))
+
+    return (b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", ihdr)
+            + chunk(b"IDAT", zlib.compress(bytes(raw_rows), 9))
+            + chunk(b"IEND", b""))
+
+
+def synthetic_cutout_png(edge_halo=False):
+    width = height = 128
+    cx = cy = width // 2
+    body_radius = 38
+    accent_radius = 10
+    pixels = [MAGENTA] * (width * height)
+    for y in range(height):
+        for x in range(width):
+            dist2 = (x - cx) ** 2 + (y - cy) ** 2
+            idx = y * width + x
+            if edge_halo and body_radius ** 2 < dist2 <= (body_radius + 2) ** 2:
+                pixels[idx] = PINK
+            elif dist2 <= body_radius ** 2:
+                pixels[idx] = CREAM
+            if not edge_halo and (x - cx) ** 2 + (y - cy) ** 2 <= accent_radius ** 2:
+                pixels[idx] = PINK
+    return rgb_png(width, height, pixels)
+
+
+def rgba_at(parsed, x, y):
+    width, _, rgba = parsed
+    offset = (y * width + x) * 4
+    return tuple(rgba[offset:offset + 4])
+
+
+class CutoutChromaTests(unittest.TestCase):
+    def setUp(self):
+        self.illo = load_illo_module()
+
+    def test_interior_pink_accent_does_not_discard_chroma_cutout(self):
+        source = synthetic_cutout_png(edge_halo=False)
+        keyed = self.illo.chroma_key_to_png(source, key=self.illo.CHROMA_MAGENTA)
+        self.assertIsNotNone(keyed)
+        analysis = self.illo.analyze_cutout_alpha(keyed)
+        self.assertTrue(analysis["clean_alpha"])
+        self.assertEqual(analysis["accent_halo"], 0)
+
+        with tempfile.TemporaryDirectory() as td:
+            out, _, _, meta = self.illo.place_cutout_image(
+                source, Path(td) / "cutout.png", chroma_key=self.illo.CHROMA_MAGENTA
+            )
+            parsed = self.illo._parse_png_rgb_or_rgba(out.read_bytes())
+
+        self.assertTrue(meta["cutout_alpha"])
+        self.assertEqual(meta["cutout_method"], "chroma")
+        self.assertEqual(rgba_at(parsed, 0, 0)[3], 0)
+        self.assertEqual(rgba_at(parsed, 127, 0)[3], 0)
+        self.assertEqual(rgba_at(parsed, 0, 127)[3], 0)
+        self.assertEqual(rgba_at(parsed, 127, 127)[3], 0)
+        self.assertEqual(rgba_at(parsed, 64, 64), PINK + (255,))
+
+    def test_outer_pink_halo_warns_but_keeps_chroma_cutout(self):
+        source = synthetic_cutout_png(edge_halo=True)
+
+        with tempfile.TemporaryDirectory() as td:
+            out, _, _, meta = self.illo.place_cutout_image(
+                source, Path(td) / "cutout.png", chroma_key=self.illo.CHROMA_MAGENTA
+            )
+            parsed = self.illo._parse_png_rgb_or_rgba(out.read_bytes())
+
+        self.assertTrue(meta["cutout_alpha"])
+        self.assertEqual(meta["cutout_method"], "chroma")
+        self.assertEqual(rgba_at(parsed, 0, 0)[3], 0)
+        self.assertEqual(rgba_at(parsed, 127, 127)[3], 0)
+        self.assertRegex((meta["cutout_note"] or "").lower(), r"accent|halo|fringe")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cutout_chroma.py
+++ b/tests/test_cutout_chroma.py
@@ -98,6 +98,24 @@ def synthetic_soft_alpha_fringe_png(soft_layers=1):
     return rgba_png(width, height, pixels)
 
 
+def synthetic_accent_ring_behind_soft_matte_png(soft_layers=5):
+    width = height = 128
+    cx = cy = width // 2
+    body_radius = 34
+    pixels = [TRANSPARENT] * (width * height)
+    for y in range(height):
+        for x in range(width):
+            dist = ((x - cx) ** 2 + (y - cy) ** 2) ** 0.5
+            idx = y * width + x
+            if dist <= body_radius:
+                pixels[idx] = CREAM + (255,)
+            elif dist <= body_radius + 1:
+                pixels[idx] = PINK + (255,)
+            elif dist <= body_radius + 1 + soft_layers:
+                pixels[idx] = CREAM + (64,)
+    return rgba_png(width, height, pixels)
+
+
 def synthetic_interior_soft_patch_png():
     width = height = 128
     cx = cy = width // 2
@@ -182,6 +200,24 @@ class CutoutChromaTests(unittest.TestCase):
         self.assertEqual(meta["cutout_method"], "chroma")
         self.assertEqual(rgba_at(parsed, 0, 0)[3], 0)
         self.assertEqual(rgba_at(parsed, 127, 127)[3], 0)
+        self.assertRegex((meta["cutout_note"] or "").lower(), r"accent|halo|fringe")
+
+    def test_pink_ring_behind_wide_soft_matte_warns_without_discarding_cutout(self):
+        source = synthetic_accent_ring_behind_soft_matte_png(soft_layers=5)
+        analysis = self.illo.analyze_cutout_alpha(source)
+
+        self.assertTrue(analysis["clean_alpha"])
+        self.assertGreaterEqual(analysis["accent_halo"], self.illo.CUTOUT_FRINGE_WARN)
+
+        with tempfile.TemporaryDirectory() as td:
+            out, _, _, meta = self.illo.place_cutout_image(
+                source, Path(td) / "cutout.png", chroma_key=self.illo.CHROMA_MAGENTA
+            )
+            parsed = self.illo._parse_png_rgb_or_rgba(out.read_bytes())
+
+        self.assertTrue(meta["cutout_alpha"])
+        self.assertEqual(meta["cutout_method"], "native")
+        self.assertEqual(rgba_at(parsed, 0, 0)[3], 0)
         self.assertRegex((meta["cutout_note"] or "").lower(), r"accent|halo|fringe")
 
     def test_soft_alpha_screen_fringe_warns_without_discarding_cutout(self):

--- a/tests/test_cutout_chroma.py
+++ b/tests/test_cutout_chroma.py
@@ -87,14 +87,28 @@ def synthetic_soft_alpha_fringe_png():
     pixels = [TRANSPARENT] * (width * height)
     for y in range(height):
         for x in range(width):
-            dist2 = (x - cx) ** 2 + (y - cy) ** 2
+            dist = ((x - cx) ** 2 + (y - cy) ** 2) ** 0.5
             idx = y * width + x
-            if dist2 <= body_radius ** 2:
+            if dist <= body_radius:
                 pixels[idx] = CREAM + (255,)
-            elif dist2 <= (body_radius + 2) ** 2:
+            elif dist <= body_radius + 1:
                 pixels[idx] = GREEN + (255,)
-            elif dist2 <= (body_radius + 6) ** 2:
+            elif dist <= body_radius + 2:
                 pixels[idx] = CREAM + (64,)
+    return rgba_png(width, height, pixels)
+
+
+def synthetic_interior_soft_patch_png():
+    width = height = 128
+    cx = cy = width // 2
+    body_radius = 40
+    pixels = [TRANSPARENT] * (width * height)
+    for y in range(height):
+        for x in range(width):
+            if (x - cx) ** 2 + (y - cy) ** 2 <= body_radius ** 2:
+                pixels[y * width + x] = CREAM + (255,)
+    pixels[cy * width + cx] = PINK + (64,)
+    pixels[cy * width + cx + 1] = CREAM + (64,)
     return rgba_png(width, height, pixels)
 
 
@@ -143,6 +157,17 @@ class CutoutChromaTests(unittest.TestCase):
         self.assertEqual(meta["cutout_method"], "chroma")
         self.assertEqual(rgba_at(parsed, 64, 18), PINK + (255,))
         self.assertIsNone(meta["cutout_note"])
+
+    def test_adjacent_interior_soft_pixels_do_not_self_trigger_fringe(self):
+        source = synthetic_interior_soft_patch_png()
+        analysis = self.illo.analyze_cutout_alpha(source)
+
+        self.assertTrue(analysis["clean_alpha"])
+        self.assertEqual(analysis["green_fringe"], 0)
+        self.assertEqual(analysis["magenta_fringe"], 0)
+        self.assertEqual(analysis["accent_halo"], 0)
+        self.assertEqual(analysis["fringe"], 0)
+        self.assertIsNone(self.illo._cutout_quality_note(analysis))
 
     def test_outer_pink_ring_warns_but_keeps_chroma_cutout(self):
         source = synthetic_cutout_png(accent="ring")

--- a/tests/test_cutout_chroma.py
+++ b/tests/test_cutout_chroma.py
@@ -12,6 +12,8 @@ SCRIPT_PATH = Path(__file__).resolve().parents[1] / "skills" / "illo" / "scripts
 MAGENTA = (255, 0, 255)
 CREAM = (248, 234, 205)
 PINK = (255, 61, 154)
+GREEN = (0, 255, 0)
+TRANSPARENT = (255, 0, 255, 0)
 
 
 def load_illo_module():
@@ -40,7 +42,24 @@ def rgb_png(width, height, pixels):
             + chunk(b"IEND", b""))
 
 
-def synthetic_cutout_png(edge_halo=False):
+def rgba_png(width, height, pixels):
+    raw_rows = bytearray()
+    for y in range(height):
+        raw_rows.append(0)
+        for x in range(width):
+            raw_rows.extend(pixels[y * width + x])
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 6, 0, 0, 0)
+
+    def chunk(kind, data):
+        return (struct.pack(">I", len(data)) + kind + data
+                + struct.pack(">I", zlib.crc32(kind + data) & 0xffffffff))
+
+    return (b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", ihdr)
+            + chunk(b"IDAT", zlib.compress(bytes(raw_rows), 9))
+            + chunk(b"IEND", b""))
+
+
+def synthetic_cutout_png(accent="interior"):
     width = height = 128
     cx = cy = width // 2
     body_radius = 38
@@ -50,13 +69,33 @@ def synthetic_cutout_png(edge_halo=False):
         for x in range(width):
             dist2 = (x - cx) ** 2 + (y - cy) ** 2
             idx = y * width + x
-            if edge_halo and body_radius ** 2 < dist2 <= (body_radius + 2) ** 2:
+            if accent == "ring" and body_radius ** 2 < dist2 <= (body_radius + 2) ** 2:
                 pixels[idx] = PINK
             elif dist2 <= body_radius ** 2:
                 pixels[idx] = CREAM
-            if not edge_halo and (x - cx) ** 2 + (y - cy) ** 2 <= accent_radius ** 2:
+            if accent == "interior" and dist2 <= accent_radius ** 2:
+                pixels[idx] = PINK
+            if accent == "tip" and (x - cx) ** 2 + (y - 26) ** 2 <= 8 ** 2:
                 pixels[idx] = PINK
     return rgb_png(width, height, pixels)
+
+
+def synthetic_soft_alpha_fringe_png():
+    width = height = 128
+    cx = cy = width // 2
+    body_radius = 34
+    pixels = [TRANSPARENT] * (width * height)
+    for y in range(height):
+        for x in range(width):
+            dist2 = (x - cx) ** 2 + (y - cy) ** 2
+            idx = y * width + x
+            if dist2 <= body_radius ** 2:
+                pixels[idx] = CREAM + (255,)
+            elif dist2 <= (body_radius + 2) ** 2:
+                pixels[idx] = GREEN + (255,)
+            elif dist2 <= (body_radius + 6) ** 2:
+                pixels[idx] = CREAM + (64,)
+    return rgba_png(width, height, pixels)
 
 
 def rgba_at(parsed, x, y):
@@ -70,7 +109,7 @@ class CutoutChromaTests(unittest.TestCase):
         self.illo = load_illo_module()
 
     def test_interior_pink_accent_does_not_discard_chroma_cutout(self):
-        source = synthetic_cutout_png(edge_halo=False)
+        source = synthetic_cutout_png(accent="interior")
         keyed = self.illo.chroma_key_to_png(source, key=self.illo.CHROMA_MAGENTA)
         self.assertIsNotNone(keyed)
         analysis = self.illo.analyze_cutout_alpha(keyed)
@@ -91,8 +130,22 @@ class CutoutChromaTests(unittest.TestCase):
         self.assertEqual(rgba_at(parsed, 127, 127)[3], 0)
         self.assertEqual(rgba_at(parsed, 64, 64), PINK + (255,))
 
-    def test_outer_pink_halo_warns_but_keeps_chroma_cutout(self):
-        source = synthetic_cutout_png(edge_halo=True)
+    def test_pink_silhouette_tip_does_not_warn_as_accent_halo(self):
+        source = synthetic_cutout_png(accent="tip")
+
+        with tempfile.TemporaryDirectory() as td:
+            out, _, _, meta = self.illo.place_cutout_image(
+                source, Path(td) / "cutout.png", chroma_key=self.illo.CHROMA_MAGENTA
+            )
+            parsed = self.illo._parse_png_rgb_or_rgba(out.read_bytes())
+
+        self.assertTrue(meta["cutout_alpha"])
+        self.assertEqual(meta["cutout_method"], "chroma")
+        self.assertEqual(rgba_at(parsed, 64, 18), PINK + (255,))
+        self.assertIsNone(meta["cutout_note"])
+
+    def test_outer_pink_ring_warns_but_keeps_chroma_cutout(self):
+        source = synthetic_cutout_png(accent="ring")
 
         with tempfile.TemporaryDirectory() as td:
             out, _, _, meta = self.illo.place_cutout_image(
@@ -105,6 +158,20 @@ class CutoutChromaTests(unittest.TestCase):
         self.assertEqual(rgba_at(parsed, 0, 0)[3], 0)
         self.assertEqual(rgba_at(parsed, 127, 127)[3], 0)
         self.assertRegex((meta["cutout_note"] or "").lower(), r"accent|halo|fringe")
+
+    def test_soft_alpha_screen_fringe_warns_without_discarding_cutout(self):
+        source = synthetic_soft_alpha_fringe_png()
+
+        with tempfile.TemporaryDirectory() as td:
+            out, _, _, meta = self.illo.place_cutout_image(
+                source, Path(td) / "cutout.png", chroma_key=self.illo.CHROMA_MAGENTA
+            )
+            parsed = self.illo._parse_png_rgb_or_rgba(out.read_bytes())
+
+        self.assertTrue(meta["cutout_alpha"])
+        self.assertEqual(meta["cutout_method"], "native")
+        self.assertEqual(rgba_at(parsed, 0, 0)[3], 0)
+        self.assertRegex((meta["cutout_note"] or "").lower(), r"fringe")
 
 
 if __name__ == "__main__":

--- a/tests/test_cutout_chroma.py
+++ b/tests/test_cutout_chroma.py
@@ -80,7 +80,7 @@ def synthetic_cutout_png(accent="interior"):
     return rgb_png(width, height, pixels)
 
 
-def synthetic_soft_alpha_fringe_png():
+def synthetic_soft_alpha_fringe_png(soft_layers=1):
     width = height = 128
     cx = cy = width // 2
     body_radius = 34
@@ -93,7 +93,7 @@ def synthetic_soft_alpha_fringe_png():
                 pixels[idx] = CREAM + (255,)
             elif dist <= body_radius + 1:
                 pixels[idx] = GREEN + (255,)
-            elif dist <= body_radius + 2:
+            elif dist <= body_radius + 1 + soft_layers:
                 pixels[idx] = CREAM + (64,)
     return rgba_png(width, height, pixels)
 
@@ -185,7 +185,21 @@ class CutoutChromaTests(unittest.TestCase):
         self.assertRegex((meta["cutout_note"] or "").lower(), r"accent|halo|fringe")
 
     def test_soft_alpha_screen_fringe_warns_without_discarding_cutout(self):
-        source = synthetic_soft_alpha_fringe_png()
+        source = synthetic_soft_alpha_fringe_png(soft_layers=1)
+
+        with tempfile.TemporaryDirectory() as td:
+            out, _, _, meta = self.illo.place_cutout_image(
+                source, Path(td) / "cutout.png", chroma_key=self.illo.CHROMA_MAGENTA
+            )
+            parsed = self.illo._parse_png_rgb_or_rgba(out.read_bytes())
+
+        self.assertTrue(meta["cutout_alpha"])
+        self.assertEqual(meta["cutout_method"], "native")
+        self.assertEqual(rgba_at(parsed, 0, 0)[3], 0)
+        self.assertRegex((meta["cutout_note"] or "").lower(), r"fringe")
+
+    def test_two_layer_soft_alpha_screen_fringe_warns_without_discarding_cutout(self):
+        source = synthetic_soft_alpha_fringe_png(soft_layers=2)
 
         with tempfile.TemporaryDirectory() as td:
             out, _, _, meta = self.illo.place_cutout_image(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fixes the chroma cutout path that discarded a successfully keyed transparent PNG when QA fringe checks failed.
- Changes alpha analysis so `clean_alpha` means the background is gone (transparent corners plus enough transparent pixels), while edge fringe and accent halos remain QA warnings in `cutout_note`.
- Scores accent-colored halos only when they behave like a ring around a substantial fraction of the opaque silhouette, so interior accents and compact locked carriers touching air do not cause re-roll notes and soft mattes do not dilute the denominator.
- Uses true-transparent edge geometry for fringe QA: direct alpha-zero adjacency, or adjacency to a soft-alpha pixel connected to air through a bounded precomputed soft mask, preventing interior soft patches from self-triggering while still catching wider AA rings.
- Adds synthetic chroma cutout tests for interior pink accents, compact silhouette accent carriers, outer pink rings, accent rings behind wide soft mattes, one- and two-layer soft-alpha screen fringe, and interior adjacent soft pixels.
- Documents the lean idle-loop / bot-avatar path using one transparent cutout and programmatic motion, with a must-pass / fail-signal QA loop and pack-specific personality moves instead of a default generic head bob.

## Testing
- `python3 -m unittest tests.test_cutout_chroma tests.test_codex_backend tests.test_grok_backend tests.test_validate_pr_commits`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b34e226-7d5c-4c9f-b2e0-ff1081b0a070?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b34e226-7d5c-4c9f-b2e0-ff1081b0a070&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

