### PR TITLE
fix: point Grok Bot install at the shareable template

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Use your runtime's native plugin or skill manager.
 | **Claude Code** | `/plugin marketplace add tmchow/illo-skill` then `/plugin install illo@illo-skill` | `claude plugin update illo`, or enable marketplace auto-update |
 | **Codex** | `codex plugin marketplace add tmchow/illo-skill` then `codex plugin add illo@illo-skill` | `codex plugin marketplace upgrade` |
 | **Grok CLI** | `grok plugin marketplace add tmchow/illo-skill` then `grok plugin install tmchow/illo-skill --trust` | `grok plugin update illo` |
-| **Grok Bot** | paste the prompt below into Grok Bot. | paste the prompt again after updates |
+| **Grok Bot** | tap [the illo bot template](https://x.ai/bot/y3uTGY5hkl6iTmE-ZAX02) | add the template again after updates |
 | **Gemini CLI** | `gemini extensions install https://github.com/tmchow/illo-skill` | `gemini extensions update illo` |
 | **Copilot / GitHub CLI** | `gh skill install tmchow/illo-skill illo` (cross-agent via `--agent`) | `gh skill update illo` |
 | **Hermes** | `hermes skills install tmchow/illo-skill/illo` | `hermes skills update illo` |
@@ -59,13 +59,7 @@ Use your runtime's native plugin or skill manager.
 
 ### Grok Bot
 
-Paste this into Grok Bot; it is not a terminal command for you to run yourself.
-
-```text
-Install the illo skill and all community characters.
-
-npx skills add tmchow/illo-skill --skill illo -g -y
-```
+Open the [illo bot template](https://x.ai/bot/y3uTGY5hkl6iTmE-ZAX02) and tap **Add to Grok Bot**. That creates an illo bot on your account.
 
 Engines, models, cost, and API keys: [`skills/illo/README.md`](skills/illo/README.md).
 

--- a/skills/illo/README.md
+++ b/skills/illo/README.md
@@ -215,7 +215,7 @@ the fallback for runtimes without a native plugin/skill manager.
 | **Claude Code** | `/plugin marketplace add tmchow/illo-skill` then `/plugin install illo@illo-skill` | `claude plugin update illo`, or enable marketplace auto-update |
 | **Codex** | `codex plugin marketplace add tmchow/illo-skill` then `codex plugin add illo@illo-skill` | `codex plugin marketplace upgrade` |
 | **Grok CLI** | `grok plugin marketplace add tmchow/illo-skill` then `grok plugin install tmchow/illo-skill --trust` | `grok plugin update illo` |
-| **Grok Bot** | paste the prompt below into Grok Bot. | paste the prompt again after updates |
+| **Grok Bot** | tap [the illo bot template](https://x.ai/bot/y3uTGY5hkl6iTmE-ZAX02) | add the template again after updates |
 | **Gemini CLI** | `gemini extensions install https://github.com/tmchow/illo-skill` | `gemini extensions update illo` |
 | **Copilot / GitHub CLI** | `gh skill install tmchow/illo-skill illo` (cross-agent via `--agent`) | `gh skill update illo` |
 | **Hermes** | `hermes skills install tmchow/illo-skill/illo` | `hermes skills update illo` |
@@ -225,13 +225,7 @@ the fallback for runtimes without a native plugin/skill manager.
 
 ### Grok Bot
 
-Paste this into Grok Bot; it is not a terminal command for you to run yourself.
-
-```text
-Install the illo skill and all community characters.
-
-npx skills add tmchow/illo-skill --skill illo -g -y
-```
+Open the [illo bot template](https://x.ai/bot/y3uTGY5hkl6iTmE-ZAX02) and tap **Add to Grok Bot**. That creates an illo bot on your account.
 
 From an interactive Hermes session:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Grok Bot users can now tap the official illo bot template instead of pasting an `npx skills add` prompt. That path uses xAI's shareable bot templates: open the link, tap **Add to Grok Bot**, and the bot is created on their account.

The same install table lives in the skill README, so both copies now point at https://x.ai/bot/y3uTGY5hkl6iTmE-ZAX02.

Confirmed the template page is live and uses the **Add to Grok Bot** button. Did not complete the in-app add (needs the Grok Bot app).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04bd4-32df-7d9a-bbca-9bb7eff5423b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04bd4-32df-7d9a-bbca-9bb7eff5423b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

